### PR TITLE
Bug/bsm part ii

### DIFF
--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/BitStringBuilder.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/BitStringBuilder.java
@@ -17,6 +17,9 @@ public class BitStringBuilder {
       char[] chars = jsonNode.asText().trim().toCharArray();
 
       for (char i = 0; i < chars.length; i++) {
+         if (i >= enumValues.length) {
+            break;
+         }
          String bitName = enumValues[i].name();
          Boolean bitStatus = (chars[i] == '1');
          bitString.put(bitName, bitStatus);

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/BitStringBuilder.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/BitStringBuilder.java
@@ -3,8 +3,12 @@ package us.dot.its.jpo.ode.plugin.j2735.builders;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import us.dot.its.jpo.ode.plugin.j2735.J2735BitString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BitStringBuilder {
+
+   private static final Logger logger = LoggerFactory.getLogger(BitStringBuilder.class);
 
    private BitStringBuilder() {
       throw new UnsupportedOperationException();
@@ -18,6 +22,7 @@ public class BitStringBuilder {
 
       for (char i = 0; i < chars.length; i++) {
          if (i >= enumValues.length) {
+            logger.warn("Invalid genericBitString. Provided bit string is longer than known enum values");
             break;
          }
          String bitName = enumValues[i].name();


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Adds a check for out of bounds array index in the BitStringBuilder class. This is needed as we are seeing data come through CDOT with 16 bit values, but the enum only knows about 6 values. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
