### PR TITLE
Bug Fix - Referencing Error in SerializationUtilsTest.java

### DIFF
--- a/jpo-ode-common/src/test/java/us/dot/its/jpo/ode/util/SerializationUtilsTest.java
+++ b/jpo-ode-common/src/test/java/us/dot/its/jpo/ode/util/SerializationUtilsTest.java
@@ -15,87 +15,11 @@
  ******************************************************************************/
 package us.dot.its.jpo.ode.util;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 
 import org.junit.Test;
-
-class TestData {
-   private int i;
-   private String s;
-   private BigDecimal bd;
-   
-   public TestData() {
-      super();
-   }
-
-   public TestData(int i, String s, BigDecimal bd) {
-      super();
-      this.i = i;
-      this.s = s;
-      this.bd = bd;
-   }
-
-   public int getI() {
-      return i;
-   }
-
-   public void setI(int i) {
-      this.i = i;
-   }
-
-   public String getS() {
-      return s;
-   }
-
-   public void setS(String s) {
-      this.s = s;
-   }
-
-   public BigDecimal getBd() {
-      return bd;
-   }
-
-   public void setBd(BigDecimal bd) {
-      this.bd = bd;
-   }
-
-   @Override
-   public int hashCode() {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + ((bd == null) ? 0 : bd.hashCode());
-      result = prime * result + i;
-      result = prime * result + ((s == null) ? 0 : s.hashCode());
-      return result;
-   }
-
-   @Override
-   public boolean equals(Object obj) {
-      if (this == obj)
-         return true;
-      if (obj == null)
-         return false;
-      if (getClass() != obj.getClass())
-         return false;
-      TestData other = (TestData) obj;
-      if (bd == null) {
-         if (other.bd != null)
-            return false;
-      } else if (!bd.equals(other.bd))
-         return false;
-      if (i != other.i)
-         return false;
-      if (s == null) {
-         if (other.s != null)
-            return false;
-      } else if (!s.equals(other.s))
-         return false;
-      return true;
-   }
-
-}
 
 public class SerializationUtilsTest {
    

--- a/jpo-ode-common/src/test/java/us/dot/its/jpo/ode/util/TestData.java
+++ b/jpo-ode-common/src/test/java/us/dot/its/jpo/ode/util/TestData.java
@@ -1,0 +1,79 @@
+package us.dot.its.jpo.ode.util;
+
+import java.math.BigDecimal;
+
+public class TestData {
+   private int i;
+   private String s;
+   private BigDecimal bd;
+   
+   public TestData() {
+      super();
+   }
+
+   public TestData(int i, String s, BigDecimal bd) {
+      super();
+      this.i = i;
+      this.s = s;
+      this.bd = bd;
+   }
+
+   public int getI() {
+      return i;
+   }
+
+   public void setI(int i) {
+      this.i = i;
+   }
+
+   public String getS() {
+      return s;
+   }
+
+   public void setS(String s) {
+      this.s = s;
+   }
+
+   public BigDecimal getBd() {
+      return bd;
+   }
+
+   public void setBd(BigDecimal bd) {
+      this.bd = bd;
+   }
+
+   @Override
+   public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((bd == null) ? 0 : bd.hashCode());
+      result = prime * result + i;
+      result = prime * result + ((s == null) ? 0 : s.hashCode());
+      return result;
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj)
+         return true;
+      if (obj == null)
+         return false;
+      if (getClass() != obj.getClass())
+         return false;
+      TestData other = (TestData) obj;
+      if (bd == null) {
+         if (other.bd != null)
+            return false;
+      } else if (!bd.equals(other.bd))
+         return false;
+      if (i != other.i)
+         return false;
+      if (s == null) {
+         if (other.s != null)
+            return false;
+      } else if (!s.equals(other.s))
+         return false;
+      return true;
+   }
+
+}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
An inner class was causing one of the tests to fail. This class has been moved to its own file.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

There is no issue for this problem.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

I was testing how the ODE would work with an updated librdkafka library when I ran into this.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The unit tests have been run and verified to pass.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
