### PR TITLE
SPaT Serialization Bug

### DIFF
--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeSpatMetadata.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeSpatMetadata.java
@@ -1,5 +1,7 @@
 package us.dot.its.jpo.ode.model;
 
+import com.fasterxml.jackson.annotation.*;
+
 public class OdeSpatMetadata extends OdeLogMetadata {
 	/**
 	 * 
@@ -14,22 +16,26 @@ public class OdeSpatMetadata extends OdeLogMetadata {
 	private boolean isCertPresent;
 	private String originIp;
 
-	public boolean isCertPresent() {
+	@JsonProperty("isCertPresent")
+	public boolean getIsCertPresent() {
 		return isCertPresent;
 	}
 
-	public void setCertPresent(boolean isCertPresent) {
+	public void setIsCertPresent(boolean isCertPresent) {
 		this.isCertPresent = isCertPresent;
 	}
 
+	@JsonCreator
 	public OdeSpatMetadata() {
 		super();
 	}
 
+	@JsonCreator
 	public OdeSpatMetadata(OdeMsgPayload payload) {
 		super(payload);
 	}
 
+	@JsonCreator
 	public OdeSpatMetadata(OdeMsgPayload payload, SerialId serialId, String receivedAt) {
 
 	}

--- a/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeSpatMetadata.java
+++ b/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeSpatMetadata.java
@@ -25,17 +25,14 @@ public class OdeSpatMetadata extends OdeLogMetadata {
 		this.isCertPresent = isCertPresent;
 	}
 
-	@JsonCreator
 	public OdeSpatMetadata() {
 		super();
 	}
 
-	@JsonCreator
 	public OdeSpatMetadata(OdeMsgPayload payload) {
 		super(payload);
 	}
 
-	@JsonCreator
 	public OdeSpatMetadata(OdeMsgPayload payload, SerialId serialId, String receivedAt) {
 
 	}

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/coder/OdeSpatDataCreatorHelper.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/coder/OdeSpatDataCreatorHelper.java
@@ -50,7 +50,7 @@ public class OdeSpatDataCreatorHelper {
 		
 		if(metadataNode.findValue("certPresent") != null) {
 			boolean isCertPresent = metadataNode.findValue("certPresent").asBoolean();
-			metadata.setCertPresent(isCertPresent);
+			metadata.setIsCertPresent(isCertPresent);
 		}
 
 		if (metadata.getSchemaVersion() <= 4) {

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/coder/stream/LogFileToAsn1CodecPublisher.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/coder/stream/LogFileToAsn1CodecPublisher.java
@@ -165,7 +165,7 @@ public class LogFileToAsn1CodecPublisher implements Asn1CodecPublisher {
 				}
 				
 				if(isSpatRecord() && msgMetadata instanceof OdeSpatMetadata 
-						&& !((OdeSpatMetadata)msgMetadata).isCertPresent() )
+						&& !((OdeSpatMetadata)msgMetadata).getIsCertPresent() )
 				{
 					//Nothing: If Spat log file and IEEE1609Cert is not present, Skip the Ieee1609Dot2Data encoding					
 				}

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/importer/parser/LogFileParser.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/importer/parser/LogFileParser.java
@@ -247,7 +247,7 @@ public abstract class LogFileParser implements FileParser {
 				isCertPresent = spatLogFileParser.isCertPresent(); //update
 			}
 			odeSpatMetadata.setSpatSource(spatSource);
-			odeSpatMetadata.setCertPresent(isCertPresent);
+			odeSpatMetadata.setIsCertPresent(isCertPresent);
 		}
 
 		metadata.calculateGeneratedBy();


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This fixes the duplication of the JSON field for "isCertPresent" for SPaT messages. Previously, "isCertPresent" was being duplicated by having another field named "certPresent". This was due to method names being inconsistent. This fix both adds a Jackson annotation for ensuring the output schema is correct and alters the method names slightly to make them more consistent with Java development standards for getters and setters.
