### PR TITLE
Adding ability to ignore unknown properties when deserializing

### DIFF
--- a/jpo-ode-common/src/main/java/us/dot/its/jpo/ode/util/JsonUtils.java
+++ b/jpo-ode-common/src/main/java/us/dot/its/jpo/ode/util/JsonUtils.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.cfg.CoercionAction;
@@ -93,6 +94,18 @@ public class JsonUtils {
          return mapper.readValue(s, clazz);
       } catch (IOException e) {
          throw new JsonUtilsException("Error deserializing JSON tree to " + clazz.getName(), e);
+      }
+   }
+
+   public static Object jacksonFromJson(String s, Class<?> clazz, boolean allowUnknownProperties)
+         throws JsonUtilsException {
+      try {
+         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, !allowUnknownProperties);
+         return mapper.readValue(s, clazz);
+      } catch (IOException e) {
+         throw new JsonUtilsException("Error deserializing JSON tree to " + clazz.getName(), e);
+      } finally {
+         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, allowUnknownProperties);
       }
    }
 

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimTransmogrifier.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimTransmogrifier.java
@@ -106,7 +106,7 @@ public class TimTransmogrifier {
          OdeMsgMetadata timMetadata, SerialId serialIdJ2735) throws JsonUtilsException, XmlUtilsException {
 
       TravelerInputData inOrderTid = (TravelerInputData) JsonUtils.jacksonFromJson(encodableTidObj.toString(),
-            TravelerInputData.class);
+            TravelerInputData.class, true);
 
       ObjectNode inOrderTidObj = JsonUtils.toObjectNode(inOrderTid.toJson());
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The Jackson library by default does not allow for extraneous properties when deserializing. This helps prevent issues that may arise with improper data formats, however we require this ability when pushing a TIM through. In the TimTransmogrifier, we deserialize an OdeTravelerInputData object into a TravelerInputData object. The ODE version has additional fields that we want to simply drop during this deserialization. This PR adds an override to the JsonUtils.jacksonFromJson method to allow ignoring extraneous properties.

## How Has This Been Tested?
Tested locally, as well as in the WYDOT development environment. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
