### PR TITLE
PPM Shared Data Volume

### DIFF
--- a/docker-compose-external.yml
+++ b/docker-compose-external.yml
@@ -1,0 +1,263 @@
+# DOCKER_SHARED_VOLUME_WINDOWS should be defined for Windows host machine as C: and not defined for Linux hosts
+
+version: '3'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  kafka:
+    image: wurstmeister/kafka
+    ports:
+      - "9092:9092"
+    environment:
+      DOCKER_HOST_IP: ${DOCKER_HOST_IP}
+      ZK: ${DOCKER_HOST_IP}:2181
+      KAFKA_ADVERTISED_HOST_NAME: ${DOCKER_HOST_IP}
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_CREATE_TOPICS: "topic.OdeBsmPojo:1:1,topic.OdeSpatTxPojo:1:1,topic.OdeSpatPojo:1:1,topic.OdeSpatJson:1:1,topic.FilteredOdeSpatJson:1:1,topic.OdeSpatRxJson:1:1,topic.OdeSpatRxPojo:1:1,topic.OdeBsmJson:1:1,topic.FilteredOdeBsmJson:1:1,topic.OdeTimJson:1:1,topic.OdeTimBroadcastJson:1:1,topic.J2735TimBroadcastJson:1:1,topic.OdeDriverAlertJson:1:1,topic.Asn1DecoderInput:1:1,topic.Asn1DecoderOutput:1:1,topic.Asn1EncoderInput:1:1,topic.Asn1EncoderOutput:1:1,topic.SDWDepositorInput:1:1,topic.OdeTIMCertExpirationTimeJson:1:1,topic.OdeRawEncodedBSMJson:1:1,topic.OdeRawEncodedSPATJson:1:1,topic.OdeRawEncodedTIMJson:1:1,topic.OdeRawEncodedMAPJson:1:1,topic.OdeMapTxPojo:1:1,topic.OdeMapJson:1:1,topic.OdeRawEncodedSSMJson:1:1,topic.OdeSsmPojo:1:1,topic.OdeSsmJson:1:1,topic.OdeRawEncodedSRMJson:1:1,topic.OdeSrmTxPojo:1:1,topic.OdeSrmJson:1:1"
+      KAFKA_DELETE_TOPIC_ENABLED: "true"
+      KAFKA_CLEANUP_POLICY: "delete" # delete old logs
+      KAFKA_LOG_RETENTION_HOURS: 2
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 3000
+      KAFKA_RETENTION_MS: 7200000    # delete old logs after 2 hours
+      KAFKA_SEGMENT_MS:   7200000    # roll segment logs every 2 hours.
+                                     # This configuration controls the period of time after
+                                     # which Kafka will force the log to roll even if the segment
+                                     # file isn't full to ensure that retention can delete or compact old data.
+    depends_on:
+      - zookeeper
+    volumes:
+      - ${DOCKER_SHARED_VOLUME_WINDOWS}/var/run/docker.sock:/var/run/docker.sock
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  ode:
+    build: .
+    image: jpoode_ode:latest
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+      - "46753:46753/udp"
+      - "46800:46800/udp"
+      - "47900:47900/udp"
+      - "44900:44900/udp"
+      - "44910:44910/udp"
+      - "44920:44920/udp"
+      - "44930:44930/udp"
+      - "5555:5555/udp"
+      - "6666:6666/udp"
+    environment:
+      DOCKER_HOST_IP: ${DOCKER_HOST_IP}
+      ZK: ${DOCKER_HOST_IP}:2181
+      ODE_SECURITY_SVCS_SIGNATURE_URI: ${ODE_SECURITY_SVCS_SIGNATURE_URI}
+      ODE_RSU_USERNAME: ${ODE_RSU_USERNAME}
+      ODE_RSU_PASSWORD: ${ODE_RSU_PASSWORD}
+      # Commented out, will use SDW depositor module by default
+      #ODE_DEPOSIT_SDW_MESSAGES_OVER_WEBSOCKET: ${ODE_DEPOSIT_SDW_MESSAGES_OVER_WEBSOCKET}
+      #ODE_DDS_CAS_USERNAME: ${ODE_DDS_CAS_USERNAME}
+      #ODE_DDS_CAS_PASSWORD: ${ODE_DDS_CAS_PASSWORD}
+    depends_on:
+      - kafka
+    volumes:
+      - ${DOCKER_SHARED_VOLUME}:/jpo-ode
+      - ${DOCKER_SHARED_VOLUME}/uploads:/home/uploads
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  adm:
+    build: ./asn1_codec
+    image: jpoode_acm:latest
+    environment:
+      DOCKER_HOST_IP: ${DOCKER_HOST_IP}
+      ACM_CONFIG_FILE: adm.properties
+    depends_on:
+      - kafka
+    volumes:
+      - ${DOCKER_SHARED_VOLUME}:/asn1_codec_share
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  aem:
+    build: ./asn1_codec
+    image: jpoode_acm:latest
+    environment:
+      DOCKER_HOST_IP: ${DOCKER_HOST_IP}
+      ACM_CONFIG_FILE: aem.properties
+    depends_on:
+      - kafka
+    volumes:
+      - ${DOCKER_SHARED_VOLUME}:/asn1_codec_share
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  ppm_bsm:
+    build:
+      context: ./jpo-cvdp
+      dockerfile: Dockerfile
+    image: jpoode_ppm:latest
+    environment:
+      DOCKER_HOST_IP: ${DOCKER_HOST_IP}
+      PPM_CONFIG_FILE: cdot_ppmBsm.properties
+    volumes:
+      - ${PPM_DATA_SHARED_VOLUME}:/ppm_data
+    depends_on:
+      - kafka
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  ppm_tim:
+    build:
+      context: ./jpo-cvdp
+      dockerfile: Dockerfile
+    image: jpoode_ppm:latest
+    environment:
+      DOCKER_HOST_IP: ${DOCKER_HOST_IP}
+      PPM_CONFIG_FILE: cdot_ppmTim.properties
+    volumes:
+      - ${DOCKER_SHARED_VOLUME}:/ppm_data
+    depends_on:
+      - kafka
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  cvpep_bsm_depositor:
+    build: ./jpo-s3-deposit
+    image: jpoode_s3dep:latest
+    environment:
+      DOCKER_HOST_IP: ${DOCKER_HOST_IP}
+      DEPOSIT_BUCKET_NAME: ${CVPEP_BSM_BUCKET_NAME}
+      DEPOSIT_KEY_NAME: ${CVPEP_BSM_DEPOSIT_KEY}
+      DEPOSIT_TOPIC: ${CVPEP_BSM_TOPIC}
+      K_AWS_ACCESS_KEY_ID: ${CVPEP_BSM_K_AWS_ACCESS_KEY_ID}
+      K_AWS_SECRET_ACCESS_SECRET: ${CVPEP_BSM_K_AWS_SECRET_ACCESS_SECRET}
+      K_AWS_SESSION_TOKEN: ${CVPEP_BSM_K_AWS_SESSION_TOKEN}
+      K_AWS_EXPIRATION: ${CVPEP_BSM_K_AWS_EXPIRATION}
+      API_ENDPOINT: ${CVPEP_BSM_API_ENDPOINT}
+      HEADER_ACCEPT: ${CVPEP_BSM_HEADER_ACCEPT}
+      HEADER_X_API_KEY: ${CVPEP_BSM_HEADER_X_API_KEY}
+      DEPOSIT_GROUP: ${CVPEP_BSM_GROUP}
+    depends_on:
+     - kafka
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  rde_bsm_depositor:
+    build: ./jpo-s3-deposit
+    image: jpoode_s3dep:latest
+    environment:
+      DOCKER_HOST_IP: ${DOCKER_HOST_IP}
+      DEPOSIT_BUCKET_NAME: ${RDE_BSM_BUCKET_NAME}
+      DEPOSIT_KEY_NAME: ${RDE_BSM_DEPOSIT_KEY}
+      DEPOSIT_TOPIC: ${RDE_BSM_TOPIC}
+      K_AWS_ACCESS_KEY_ID: ${RDE_BSM_K_AWS_ACCESS_KEY_ID}
+      K_AWS_SECRET_ACCESS_SECRET: ${RDE_BSM_K_AWS_SECRET_ACCESS_SECRET}
+      K_AWS_SESSION_TOKEN: ${RDE_BSM_K_AWS_SESSION_TOKEN}
+      K_AWS_EXPIRATION: ${RDE_BSM_K_AWS_EXPIRATION}
+      API_ENDPOINT: ${RDE_BSM_API_ENDPOINT}
+      HEADER_ACCEPT: ${RDE_BSM_HEADER_ACCEPT}
+      HEADER_X_API_KEY: ${RDE_BSM_HEADER_X_API_KEY}
+      DEPOSIT_GROUP: ${RDE_BSM_GROUP}
+    depends_on:
+     - kafka
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  cvpep_tim_depositor:
+    build: ./jpo-s3-deposit
+    image: jpoode_s3dep:latest
+    environment:
+      DOCKER_HOST_IP: ${DOCKER_HOST_IP}
+      DEPOSIT_BUCKET_NAME: ${CVPEP_TIM_BUCKET_NAME}
+      DEPOSIT_KEY_NAME: ${CVPEP_TIM_DEPOSIT_KEY}
+      DEPOSIT_TOPIC: ${CVPEP_TIM_TOPIC}
+      K_AWS_ACCESS_KEY_ID: ${CVPEP_BSM_K_AWS_ACCESS_KEY_ID}
+      K_AWS_SECRET_ACCESS_SECRET: ${CVPEP_BSM_K_AWS_SECRET_ACCESS_SECRET}
+      K_AWS_SESSION_TOKEN: ${CVPEP_BSM_K_AWS_SESSION_TOKEN}
+      K_AWS_EXPIRATION: ${CVPEP_BSM_K_AWS_EXPIRATION}
+      API_ENDPOINT: ${CVPEP_BSM_API_ENDPOINT}
+      HEADER_ACCEPT: ${CVPEP_BSM_HEADER_ACCEPT}
+      HEADER_X_API_KEY: ${CVPEP_BSM_HEADER_X_API_KEY}
+      DEPOSIT_GROUP: ${CVPEP_TIM_GROUP}
+    depends_on:
+     - kafka
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  rde_tim_depositor:
+    build: ./jpo-s3-deposit
+    image: jpoode_s3dep:latest
+    environment:
+      DOCKER_HOST_IP: ${DOCKER_HOST_IP}
+      DEPOSIT_BUCKET_NAME: ${RDE_TIM_BUCKET_NAME}
+      DEPOSIT_KEY_NAME: ${RDE_TIM_DEPOSIT_KEY}
+      DEPOSIT_TOPIC: ${RDE_TIM_TOPIC}
+      K_AWS_ACCESS_KEY_ID: ${CVPEP_BSM_K_AWS_ACCESS_KEY_ID}
+      K_AWS_SECRET_ACCESS_SECRET: ${RDE_TIM_K_AWS_SECRET_ACCESS_SECRET}
+      K_AWS_SESSION_TOKEN: ${RDE_TIM_K_AWS_SESSION_TOKEN}
+      K_AWS_EXPIRATION: ${RDE_TIM_K_AWS_EXPIRATION}
+      API_ENDPOINT: ${RDE_TIM_API_ENDPOINT}
+      HEADER_ACCEPT: ${RDE_TIM_HEADER_ACCEPT}
+      HEADER_X_API_KEY: ${RDE_TIM_HEADER_X_API_KEY}
+      DEPOSIT_GROUP: ${RDE_TIM_GROUP}
+    depends_on:
+     - kafka
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  sdw_depositor:
+    build: ./jpo-sdw-depositor
+    image: jpoode_sdwdep:latest
+    environment:
+      DOCKER_HOST_IP: ${DOCKER_HOST_IP}
+      #SDW_GROUP_ID: ${SDW_GROUP_ID}
+      #SDW_KAFKA_PORT: ${SDW_KAFKA_PORT}
+      #SDW_SUBSCRIPTION_TOPICS: ${SDW_SUBSCRIPTION_TOPICS}
+      #SDW_DESTINATION_URL: ${SDW_DESTINATION_URL}
+      SDW_API_KEY: ${SDW_API_KEY}
+    depends_on:
+     - kafka
+     - zookeeper
+     - ode
+    logging:
+      options:
+        max-size: "10m" 
+        max-file: "5"
+
+  sec:
+    build: ./jpo-security-svcs
+    image: jpoode_sec:latest
+    ports:
+     - "8090:8090"
+    environment:
+      SEC_CRYPTO_SERVICE_BASE_URI: ${SEC_CRYPTO_SERVICE_BASE_URI}
+    logging:
+      options:
+        max-size: "10m"  
+        max-file: "5"

--- a/sample.env
+++ b/sample.env
@@ -32,7 +32,8 @@ DOCKER_HOST_IP=
 DOCKER_SHARED_VOLUME=
 DOCKER_SHARED_VOLUME_WINDOWS=C:
 
-# (Alternatively) The full path of a directory on the host machine to be shared with containers running the PPM image.
+# (Required when using docker-compose-external.yml) 
+# The full path of a directory on the host machine that contains the edges and properties files necessary to run the PPM.
 PPM_DATA_SHARED_VOLUME=
 
 # (Required if values are not sent in REST request JSON messages)

--- a/sample.env
+++ b/sample.env
@@ -32,6 +32,9 @@ DOCKER_HOST_IP=
 DOCKER_SHARED_VOLUME=
 DOCKER_SHARED_VOLUME_WINDOWS=C:
 
+# (Alternatively) The full path of a directory on the host machine to be shared with containers running the PPM image.
+PPM_DATA_SHARED_VOLUME=
+
 # (Required if values are not sent in REST request JSON messages)
 # RSU SNMP username and password
 ODE_RSU_USERNAME=


### PR DESCRIPTION
# Purpose
A new docker-compose file has been added which makes use of the PPM_DATA_SHARED_VOLUME environment variable rather than the DOCKER_SHARED_VOLUME environment variable when spinning up containers using the PPM image.

## Notes
- A new docker-compose called docker-compose-external.yml has been added to the project.
- When using docker-compose-external.yml, the PPM_DATA_SHARED_VOLUME environment variable must be set in addition to the DOCKER_SHARED_VOLUME environment variable.
- It is expected that the directory specified by the PPM_DATA_SHARED_VOLUME environment variable will contain the edges and properties files necessary to run the PPM.