### PR TITLE
C++ Debugging Support in Dev Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -67,3 +67,8 @@ RUN chmod 775 /etc/init.d/kafka && update-rc.d kafka defaults
 COPY ./docker-entrypoint.sh ./docker-entrypoint.sh
 RUN chmod +x ./docker-entrypoint.sh
 ENTRYPOINT ["./docker-entrypoint.sh"]
+
+# C++
+RUN apt-get update
+RUN apt-get install -y libsasl2-dev libsasl2-modules libssl-dev librdkafka-dev
+RUN apt install -y autoconf libtool

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -72,3 +72,6 @@ ENTRYPOINT ["./docker-entrypoint.sh"]
 RUN apt-get update
 RUN apt-get install -y g++ cmake libsasl2-dev libsasl2-modules libssl-dev librdkafka-dev
 RUN apt install -y autoconf libtool
+
+ENV REDACTION_PROPERTIES_PATH /workspaces/jpo-ode/jpo-cvdp/config/fieldsToRedact.txt
+ENV RPM_DEBUG true

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -70,5 +70,5 @@ ENTRYPOINT ["./docker-entrypoint.sh"]
 
 # C++
 RUN apt-get update
-RUN apt-get install -y libsasl2-dev libsasl2-modules libssl-dev librdkafka-dev
+RUN apt-get install -y g++ cmake libsasl2-dev libsasl2-modules libssl-dev librdkafka-dev
 RUN apt install -y autoconf libtool

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.154.0/containers/java-8
 {
-	"name": "Java 11",
+	"name": "Java 11 and C++",
 	"dockerFile": "Dockerfile",
 	"overrideCommand": false,
 	"shutdownAction": "stopContainer",
@@ -21,7 +21,9 @@
 		"mhutchie.git-graph",
 		"tabnine.tabnine-vscode",
 		"redhat.java",
-		"redhat.vscode-commons"
+		"redhat.vscode-commons",
+		"ms-vscode.cpptools",
+		"ms-vscode.cmake-tools"
 	],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [8080, 9090, 46753, 46800, 5555, 6666, 8090, 2181, 9092],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,6 +31,9 @@
 	"postCreateCommand": "bash .devcontainer/post-create.sh",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"
+	"mounts": [
+		"source=C:\\ppm_data,target=/ppm_data,type=bind,consistency=cached"
+	],
 	"runArgs": [
 		"--network=host"
 	]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,9 +31,6 @@
 	"postCreateCommand": "bash .devcontainer/post-create.sh",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"
-	"mounts": [
-		"source=C:\\ppm_data,target=/ppm_data,type=bind,consistency=cached"
-	],
 	"runArgs": [
 		"--network=host"
 	]

--- a/README.md
+++ b/README.md
@@ -393,6 +393,9 @@ Install the IDE of your choice:
 
 * TravisCI: <https://travis-ci.org/usdot-jpo-ode/jpo-ode>
 
+### Dev Container Environment
+The project can be reopened inside of a dev container in VSCode. This environment should have all of the necessary dependencies to debug the ODE and its submodules. When attempting to run scripts in this environment, it may be necessary to make them executable with "chmod +x" first.
+
 [Back to top](#toc)
 
 <!--


### PR DESCRIPTION
# Purpose
The purpose of this PR is to make it possible to debug C++ projects in the ODE's dev container environment. With these changes, it should now be possible to run C++ code that lives in the ACM and PPM submodules when in the dev container.

# Details
The following packages are now installed in the dev container upon building the image:
- g++
- cmake
- libsasl2-dev
- libsasl2-modules
- libssl-dev
- librdkafka-dev
- autoconf
- libtool

The following extensions will now be accessible in the dev container:
- ms-vscode.cpptools
- ms-vscode.cmake-tools