### PR TITLE
Updating Base Image & Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY ./jpo-ode-svcs/src ./jpo-ode-svcs/src
 
 RUN mvn clean package -DskipTests
 
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre-alpine
 
 WORKDIR /home
 

--- a/jpo-ode-common/pom.xml
+++ b/jpo-ode-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-ode</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
   
   <artifactId>jpo-ode-common</artifactId>

--- a/jpo-ode-core/pom.xml
+++ b/jpo-ode-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-ode</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>jpo-ode-core</artifactId>
@@ -23,12 +23,12 @@
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-common</artifactId>
-      <version>1.0.10-SNAPSHOT</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-plugins</artifactId>
-      <version>1.0.10-SNAPSHOT</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/jpo-ode-plugins/pom.xml
+++ b/jpo-ode-plugins/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-ode</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
   <properties>
     <!-- SonarQube Properties -->
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-common</artifactId>
-      <version>1.0.10-SNAPSHOT</version>
+      <version>1.3.0</version>
     </dependency>
     <!-- TODO open-ode
     <dependency>

--- a/jpo-ode-svcs/pom.xml
+++ b/jpo-ode-svcs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-ode</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
   <artifactId>jpo-ode-svcs</artifactId>
   <packaging>jar</packaging>
@@ -101,12 +101,12 @@
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-core</artifactId>
-      <version>1.0.10-SNAPSHOT</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-plugins</artifactId>
-      <version>1.0.10-SNAPSHOT</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <groupId>usdot.jpo.ode</groupId>
   <artifactId>jpo-ode</artifactId>
-  <version>1.0.10-SNAPSHOT</version>
+  <version>1.3.0</version>
   <packaging>pom</packaging>
   <modules>
     <module>jpo-ode-common</module>


### PR DESCRIPTION
The base image has been updated to eclipse-temurin:11-jre-alpine rather than openjdk:8-jre-alpine and the versions in the relevant pom.xml files have been updated to 1.3.0 to match the version being used for the release.

This has been tested locally w/ docker-compose and in our dev cluster.