### PR TITLE
Revert BSM schema

### DIFF
--- a/jpo-ode-core/src/main/resources/schemas/schema-bsm.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-bsm.json
@@ -296,6 +296,7 @@
                                             ]
                                         }
                                     },
+                                    "required": [],
                                     "type": "object"
                                 },
                                 "angle": {
@@ -407,6 +408,7 @@
                                             ]
                                         }
                                     },
+                                    "required": [],
                                     "type": "object"
                                 },
                                 "speed": {
@@ -695,6 +697,7 @@
                                                                                 ]
                                                                             }
                                                                         },
+                                                                        "required": [],
                                                                         "type": "object"
                                                                     },
                                                                     "posConfidence": {
@@ -942,6 +945,7 @@
                                                                                 ]
                                                                             }
                                                                         },
+                                                                        "required": [],
                                                                         "type": [
                                                                             "object",
                                                                             "null"
@@ -984,6 +988,7 @@
                                                         ]
                                                     }
                                                 },
+                                                "required": [],
                                                 "type": "object"
                                             }
                                         },
@@ -1147,6 +1152,7 @@
                                                                 "type": "integer"
                                                             }
                                                         },
+                                                        "required": [],
                                                         "type": [
                                                             "object",
                                                             "null"
@@ -1497,6 +1503,7 @@
                                                         ]
                                                     }
                                                 },
+                                                "required": [],
                                                 "type": "object"
                                             }
                                         },
@@ -1680,6 +1687,7 @@
                                                                 ]
                                                             }
                                                         },
+                                                        "required": [],
                                                         "type": [
                                                             "object",
                                                             "null"
@@ -1738,6 +1746,7 @@
                                                                         ]
                                                                     }
                                                                 },
+                                                                "required": [],
                                                                 "type": [
                                                                     "object",
                                                                     "null"
@@ -1838,6 +1847,7 @@
                                                                 "type": "array"
                                                             }
                                                         },
+                                                        "required": [],
                                                         "type": [
                                                             "object",
                                                             "null"
@@ -2002,6 +2012,7 @@
                                                                 ]
                                                             }
                                                         },
+                                                        "required": [],
                                                         "type": [
                                                             "object",
                                                             "null"
@@ -2071,6 +2082,7 @@
                                                                 ]
                                                             }
                                                         },
+                                                        "required": [],
                                                         "type": [
                                                             "object",
                                                             "null"
@@ -2146,6 +2158,7 @@
                                                         ]
                                                     }
                                                 },
+                                                "required": [],
                                                 "type": "object"
                                             }
                                         },

--- a/jpo-ode-core/src/main/resources/schemas/schema-bsm.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-bsm.json
@@ -339,11 +339,23 @@
                                                     "type": "boolean"
                                                 }
                                             },
+                                            "required": [
+                                                "unavailable",
+                                                "leftFront",
+                                                "leftRear",
+                                                "rightFront",
+                                                "rightRear"
+                                            ],
                                             "type": "object"
                                         }
                                     },
                                     "required": [
-                                        "wheelBrakes"
+                                        "wheelBrakes",
+                                        "traction",
+                                        "abs",
+                                        "scs",
+                                        "brakeBoost",
+                                        "auxBrakes"
                                     ],
                                     "type": "object"
                                 },
@@ -421,6 +433,7 @@
                                 "position",
                                 "accelSet",
                                 "accuracy",
+                                "transmission",
                                 "speed",
                                 "heading",
                                 "brakes",
@@ -484,11 +497,17 @@
                                                         "required": [
                                                             "eventHazardLights",
                                                             "eventStopLineViolation",
+                                                            "eventABSactivated",
+                                                            "eventTractionControlLoss",
+                                                            "eventStabilityControlactivated",
                                                             "eventHazardousMaterials",
                                                             "eventReserved1",
                                                             "eventHardBraking",
                                                             "eventLightsChanged",
-                                                            "eventWipersChanged"
+                                                            "eventWipersChanged",
+                                                            "eventFlatTire",
+                                                            "eventDisabledVehicle",
+                                                            "eventAirBagDeployment"
                                                         ],
                                                         "type": [
                                                             "object",
@@ -525,6 +544,17 @@
                                                                 "type": "boolean"
                                                             }
                                                         },
+                                                        "required": [
+                                                            "lowBeamHeadlightsOn",
+                                                            "highBeamHeadlightsOn",
+                                                            "leftTurnSignalOn",
+                                                            "rightTurnSignalOn",
+                                                            "hazardSignalOn",
+                                                            "automaticLightControlOn",
+                                                            "daytimeRunningLightsOn",
+                                                            "fogLightOn",
+                                                            "parkingLightsOn"
+                                                        ],
                                                         "type": [
                                                             "object",
                                                             "null"
@@ -1839,6 +1869,9 @@
                                                                 "type": "integer"
                                                             }
                                                         },
+                                                        "required": [
+                                                            "statusDetails"
+                                                        ],
                                                         "type": [
                                                             "object",
                                                             "null"
@@ -2028,6 +2061,10 @@
                                                                         ]
                                                                     }
                                                                 },
+                                                                "required": [
+                                                                    "rateFront",
+                                                                    "statusFront"
+                                                                ],
                                                                 "type": [
                                                                     "object",
                                                                     "null"


### PR DESCRIPTION
Reverts the BSM schema back to what it was originally. Keeps the removal of filtered BSM since it is no longer needed.