### PR TITLE
Removed DOCKER_SHARED_VOLUME_WINDOWS env var

### DIFF
--- a/docker-compose-confluent-cloud.yml
+++ b/docker-compose-confluent-cloud.yml
@@ -1,5 +1,3 @@
-# DOCKER_SHARED_VOLUME_WINDOWS should be defined for Windows host machine as C: and not defined for Linux hosts
-
 version: '3'
 services:
   ode:

--- a/docker-compose-ppm-nsv.yml
+++ b/docker-compose-ppm-nsv.yml
@@ -1,8 +1,6 @@
 # This docker-compose file configures PPM modules with self contained configuration and map files
 # So the module can run without reliance on a shared volume. This was done to avoid corporate network
 # and machine dress-code restrictions that would not permit the container sharing volume with host.
-#
-# DOCKER_SHARED_VOLUME_WINDOWS should be defined for Windows host machine as C: and not defined for Linux hosts
 
 version: '3'
 services:
@@ -34,7 +32,7 @@ services:
     depends_on:
       - zookeeper
     volumes:
-      - ${DOCKER_SHARED_VOLUME_WINDOWS}/var/run/docker.sock:/var/run/docker.sock
+      - ${DOCKER_SHARED_VOLUME}/var/run/docker.sock:/var/run/docker.sock
 
   ode:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-# DOCKER_SHARED_VOLUME_WINDOWS should be defined for Windows host machine as C: and not defined for Linux hosts
-
 version: '3'
 services:
   zookeeper:
@@ -34,7 +32,7 @@ services:
     depends_on:
       - zookeeper
     volumes:
-      - ${DOCKER_SHARED_VOLUME_WINDOWS}/var/run/docker.sock:/var/run/docker.sock
+      - ${DOCKER_SHARED_VOLUME}/var/run/docker.sock:/var/run/docker.sock
     logging:
       options:
         max-size: "10m"


### PR DESCRIPTION
## Problem
The DOCKER_SHARED_VOLUME_WINDOWS environment variable is no longer needed.

## Solution
The DOCKER_SHARED_VOLUME_WINDOWS environment variable has been removed.

## Testing
Spinning up the project using docker-compose has been verified to work with these changes.