### PR TITLE
Changed version to 1.6.0-SNAPSHOT

### DIFF
--- a/jpo-ode-common/pom.xml
+++ b/jpo-ode-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-ode</artifactId>
-    <version>1.3.0</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>jpo-ode-common</artifactId>

--- a/jpo-ode-core/pom.xml
+++ b/jpo-ode-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-ode</artifactId>
-    <version>1.3.0</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jpo-ode-core</artifactId>
@@ -23,12 +23,12 @@
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-common</artifactId>
-      <version>1.3.0</version>
+      <version>1.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-plugins</artifactId>
-      <version>1.3.0</version>
+      <version>1.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/jpo-ode-plugins/pom.xml
+++ b/jpo-ode-plugins/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-ode</artifactId>
-    <version>1.3.0</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
   <properties>
     <!-- SonarQube Properties -->
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-common</artifactId>
-      <version>1.3.0</version>
+      <version>1.6.0-SNAPSHOT</version>
     </dependency>
     <!-- TODO open-ode
     <dependency>

--- a/jpo-ode-svcs/pom.xml
+++ b/jpo-ode-svcs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-ode</artifactId>
-    <version>1.3.0</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
   <artifactId>jpo-ode-svcs</artifactId>
   <packaging>jar</packaging>
@@ -102,12 +102,12 @@
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-core</artifactId>
-      <version>1.3.0</version>
+      <version>1.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-plugins</artifactId>
-      <version>1.3.0</version>
+      <version>1.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/jpo-ode-svcs/run.bat
+++ b/jpo-ode-svcs/run.bat
@@ -1,1 +1,1 @@
-java -jar target\jpo-ode-svcs-1.3.0.jar 
+java -jar target\jpo-ode-svcs-1.6.0-SNAPSHOT.jar 

--- a/jpo-ode-svcs/run.sh
+++ b/jpo-ode-svcs/run.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-java -jar target/jpo-ode-svcs-1.3.0.jar 
+java -jar target/jpo-ode-svcs-1.6.0-SNAPSHOT.jar 

--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,12 @@
 
   <scm>
     <developerConnection>scm:git:https://github.com/usdot-jpo-ode/jpo-ode.git</developerConnection>
-    <tag>jpo-ode-1.3.0</tag>
+    <tag>jpo-ode-1.6.0-SNAPSHOT</tag>
   </scm>
 
   <groupId>usdot.jpo.ode</groupId>
   <artifactId>jpo-ode</artifactId>
-  <version>1.3.0</version>
+  <version>1.6.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>jpo-ode-common</module>


### PR DESCRIPTION
## Problem
The version in the pom.xml files are outdated.

## Solution
The version have been updated to 1.6.0-SNAPSHOT in the following files:
- jpo-ode-common/pom.xml
- jpo-ode-core/pom.xml
- jpo-ode-plugins/pom.xml
- jpo-ode-svcs/pom.xml
- jpo-ode-svcs/run.bat
- jpo-ode-svcs/run.sh
- pom.xml

## Testing
The tests pass & the project compiles.

## Note
The 'release.properties' file still needs to be updated by running `mvn release:prepare`, but this isn't working for me so we may have to leave it for USDOT.