### PR TITLE
Trim Nanoseconds from snmpTimestampFromIso

### DIFF
--- a/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/snmp/SNMPTest.java
+++ b/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/snmp/SNMPTest.java
@@ -76,4 +76,10 @@ public class SNMPTest {
       String snmpTS = SNMP.snmpTimestampFromIso("2017-05-04T21:55:00-05:00");
       assertEquals("07E1050415370000", snmpTS);
    }
+
+   @Test
+   public void testSnmpTimestampFromIsoNanosecondFormat() throws ParseException {
+      String snmpTS = SNMP.snmpTimestampFromIso("2024-03-01T20:29:33.033Z");
+      assertEquals("07E80301141D211F", snmpTS);
+   }
 }

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/SNMP.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/SNMP.java
@@ -136,7 +136,8 @@ public class SNMP extends OdeObject {
       sb.append(String.format("%02X", zdt.getHour()));
       sb.append(String.format("%02X", zdt.getMinute()));
       sb.append(String.format("%02X", zdt.getSecond()));
-      sb.append(String.format("%02X", zdt.getNano()));
+      sb.append(String.format("%02X", zdt.getNano()).substring(0, 2));
+
       return sb.toString();
    }
 


### PR DESCRIPTION
This includes an update to snmpTimestampFromIso to trim nanoseconds to a length of two. This fixes an issue that was discovered when a timestamp of the form YYYY-MM-DDTHH:mm:ss.sssZ is passed to this method. 

An additional unit test was added to test this method with a timestamp of the form YYYY-MM-DDTHH:mm:ss.sssZ. 

- [ X ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ X ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
