### PR TITLE
Added Submodule Compatibility Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The following guide contains information about the data flow diagrams for the OD
 - Additionally `git` commands may fail for similar reasons, you can fix this by running `export GIT_SSL_NO_VERIFY=1`.
 - Windows users may find more information on installing and using Docker [here](https://github.com/usdot-jpo-ode/jpo-ode/wiki/Docker-management).
 - Users interested in Kafka may find more guidance and configuration options [here](docker/kafka/README.md).
-- A compatibility guide containing recommended suitable versions of submodules for each main module version can be found [here](docs/compatibility.md).
+- A compatibility guide containing recommendations for suitable versions of submodules for each main module version can be found [here](docs/compatibility.md).
 
 **Configuration:**
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The following guide contains information about the data flow diagrams for the OD
 - Additionally `git` commands may fail for similar reasons, you can fix this by running `export GIT_SSL_NO_VERIFY=1`.
 - Windows users may find more information on installing and using Docker [here](https://github.com/usdot-jpo-ode/jpo-ode/wiki/Docker-management).
 - Users interested in Kafka may find more guidance and configuration options [here](docker/kafka/README.md).
+- A compatibility guide containing recommended suitable versions of submodules for each main module version can be found [here](docs/compatibility.md).
 
 **Configuration:**
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,4 +1,4 @@
-# Compatibility Matrix (Recommended Versions)
+# Submodule Compatibility Guide
 This table serves as a guide, suggesting which versions of individual submodules are best suited to accompany each version of the main module. It helps users ensure compatibility and smooth integration by recommending specific submodule versions for their chosen main module version.
 
 | [ODE (this project)](https://github.com/usdot-jpo-ode/jpo-ode/releases) | [ACM](https://github.com/usdot-jpo-ode/asn1_codec/releases) | [PPM](https://github.com/usdot-jpo-ode/jpo-cvdp/releases) | [SEC](https://github.com/usdot-jpo-ode/jpo-security-svcs/releases) | [SDWD](https://github.com/usdot-jpo-ode/jpo-sdw-depositor/releases) | [S3D](https://github.com/usdot-jpo-ode/jpo-s3-deposit/releases) | [GJConverter](https://github.com/usdot-jpo-ode/jpo-geojsonconverter/releases) | [CMonitor](https://github.com/usdot-jpo-ode/jpo-conflictmonitor/releases) | [CVisualizer](https://github.com/usdot-jpo-ode/jpo-conflictvisualizer/releases) | [CVManager](https://github.com/usdot-jpo-ode/jpo-cvmanager/releases) |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,12 @@
+# Compatibility Matrix (Recommended Versions)
+This table serves as a guide, suggesting which versions of individual submodules are best suited to accompany each version of the main module. It helps users ensure compatibility and smooth integration by recommending specific submodule versions for their chosen main module version.
+
+| [ODE (this project)](https://github.com/usdot-jpo-ode/jpo-ode/releases) | [ACM](https://github.com/usdot-jpo-ode/asn1_codec/releases) | [PPM](https://github.com/usdot-jpo-ode/jpo-cvdp/releases) | [SEC](https://github.com/usdot-jpo-ode/jpo-security-svcs/releases) | [SDWD](https://github.com/usdot-jpo-ode/jpo-sdw-depositor/releases) | [S3D](https://github.com/usdot-jpo-ode/jpo-s3-deposit/releases) | [GJConverter](https://github.com/usdot-jpo-ode/jpo-geojsonconverter/releases) | [CMonitor](https://github.com/usdot-jpo-ode/jpo-conflictmonitor/releases) | [CVisualizer](https://github.com/usdot-jpo-ode/jpo-conflictvisualizer/releases) | [CVManager](https://github.com/usdot-jpo-ode/jpo-cvmanager/releases) |
+| ----------------- | --- | --- | --- | ---- | --- | ----------- | -------- | ----------- | ----------- |
+| 2.0.1 | 2.0.0 | 1.3.0 | 1.4.0 | 1.6.0 | 1.4.0 | 1.2.0 | 1.2.0 | 1.2.0 | 1.2.0 |
+| 1.5.1 | 1.5.0 | 1.2.0 | 1.3.0 | 1.5.0 | 1.3.0 | 1.1.0 | 1.1.0 | 1.1.0 | 1.1.0 |
+| 1.4.1 | 1.4.1 | 1.1.1 | 1.2.1 | 1.4.1 | 1.2.1 | 1.0.0 | 1.0.1 | 1.0.1 | 1.0.1 |
+| 1.4.0 | 1.4.0 | 1.1.0 | 1.2.0 | 1.4.0 | 1.2.0 | N/A | N/A | N/A | N/A |
+| 1.3.0 | 1.3.0 | 1.0.0 | 1.0.1 | 1.3.0 | 1.1.0 | N/A | N/A | N/A | N/A |
+
+For example, if you're using ODE version 2.0.1, it's recommended to use ACM 2.0.0, PPM 1.3.0, SEC 1.4.0, SDWD 1.6.0, S3D 1.4.0, GJConverter 1.2.0, CMonitor 1.2.0, CVisualizer 1.2.0, and CVManager 1.2.0. While other combinations may work, these versions are suggested for the best compatibility.


### PR DESCRIPTION
# PR Details
## Description
The documentation now provides clear instructions to help users select compatible versions of submodules for their chosen version of the project.

## Related Issue
No related issue.

## Motivation and Context
Previously, users lacked guidance on which submodule versions were suitable for a specific version of the project. They had to resort to methods like checking release dates, inspecting git submodule commits, or relying on the 'latest' tag on DockerHub, which was often uncertain. This update aims to simplify the deployment process.

## How Has This Been Tested?
Since this update involves documentation only, no testing is required.

## Types of changes
- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)
- [x] Documentation

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
