### PR TITLE
Added 'Submodule Compatibility Guide' link to dockerhub documentation

### DIFF
--- a/docs/dockerhub.md
+++ b/docs/dockerhub.md
@@ -27,6 +27,9 @@ Some functionality will be unreachable without the participation of the followin
 - jpo-sdw-depositor
 - jpo-s3-deposit
 
+### Submodule Compatibility
+To find the compatible submodule versions, please refer to the [Submodule Compatibility Guide](https://github.com/CDOT-CV/jpo-ode/blob/dev/docs/compatibility.md). Based on your ODE version, you can find the compatible submodule versions by looking at the corresponding row of the provided table.
+
 ## Configuration
 For further configuration options, see the [GitHub repository](https://github.com/usdot-jpo-ode/jpo-ode).
 


### PR DESCRIPTION
# PR Details
## Description
### Problem
The dockerhub documentation for the project references submodules, but does not provide guidance on what versions of the submodules to use.

## Solution
A link to the 'Submodule Compatibility Guide' has been added to the dockerhub documentation. This is currently linking to the CDOT fork, as the guide does not yet exist in the parent project. A local reference would have been used, but the dockerhub documentation is expected to be posted on the DockerHub page for the ODE image, so a direct link is more suited here.

## Related Issue
No related GitHub issue.

## Motivation and Context
Users who are reading the dockerhub documentation should be aware of the Submodule Compatibility Guide.

## How Has This Been Tested?
Clicking on the link has been verified to properly redirect to the blob page on the dev branch of CDOT's fork.

## Types of changes
- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)
- [x] Documentation update

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
