### PR TITLE
Update Maven Plugin Versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,9 +137,9 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.2.5</version>
           <configuration>
-            <argLine>-javaagent:${user.home}/.m2/repository/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar</argLine>
+            <argLine>-javaagent:${user.home}/.m2/repository/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar -Xshare:off</argLine>
             <!-- <testFailureIgnore>true</testFailureIgnore> -->
             <systemPropertyVariables>
               <loader.path>${loader.path}</loader.path>
@@ -150,14 +150,14 @@
             <dependency>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
-              <version>3.1.2</version>
-            </dependency>
+              <version>3.2.5</version>
+          </dependency>
           </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>3.0.1</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <plugin>
           <groupId>org.sonarsource.scanner.maven</groupId>
           <artifactId>sonar-maven-plugin</artifactId>
-          <version>3.10.0.2594</version>
+          <version>3.11.0.3922</version>
         </plugin>
         <plugin>
           <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -126,8 +126,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <source>21</source>
-            <target>21</target>
+            <release>21</release>
             <showDeprecation>true</showDeprecation>
             <compilerArgs>
               <arg>-Xlint:deprecation</arg>


### PR DESCRIPTION
# PR Details
## Description

This PR updates the maven-sonar-plugin, maven-surefire-plugin, and maven-release-plugin versions to the latest available version.

## Motivation and Context

There have been periodic sonar failures in the jpo-ode repository. Updating these plugins to the latest version should minimize the frequency of these failures. 

## How Has This Been Tested?

This has been tested by observing the output of the sonar pipeline in Github.

## Types of changes

- [ X ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
