### PR TITLE
Update Kafka topic creation

### DIFF
--- a/docker-compose-ppm-nsv.yml
+++ b/docker-compose-ppm-nsv.yml
@@ -22,8 +22,6 @@ services:
       KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"
       ALLOW_PLAINTEXT_LISTENER: "yes"
       KAFKA_CFG_NODE_ID: "1"
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
-      KAFKA_CREATE_TOPICS: "topic.OdeBsmPojo:1:1,topic.OdeSpatTxPojo:1:1,topic.OdeSpatPojo:1:1,topic.OdeSpatJson:1:1,topic.FilteredOdeSpatJson:1:1,topic.OdeSpatRxJson:1:1,topic.OdeSpatRxPojo:1:1,topic.OdeBsmJson:1:1,topic.FilteredOdeBsmJson:1:1,topic.OdeTimJson:1:1,topic.OdeTimBroadcastJson:1:1,topic.J2735TimBroadcastJson:1:1,topic.OdeDriverAlertJson:1:1,topic.Asn1DecoderInput:1:1,topic.Asn1DecoderOutput:1:1,topic.Asn1EncoderInput:1:1,topic.Asn1EncoderOutput:1:1,topic.SDWDepositorInput:1:1,topic.OdeTIMCertExpirationTimeJson:1:1,topic.OdeRawEncodedBSMJson:1:1,topic.OdeRawEncodedSPATJson:1:1,topic.OdeRawEncodedTIMJson:1:1,topic.OdeRawEncodedMAPJson:1:1,topic.OdeMapTxPojo:1:1,topic.OdeMapJson:1:1,topic.OdeRawEncodedSSMJson:1:1,topic.OdeSsmPojo:1:1,topic.OdeSsmJson:1:1,topic.OdeRawEncodedSRMJson:1:1,topic.OdeSrmTxPojo:1:1,topic.OdeSrmJson:1:1,topic.OdeRawEncodedPSMJson:1:1,topic.OdePsmTxPojo:1:1,topic.OdePsmJson:1:1"
       KAFKA_CFG_DELETE_TOPIC_ENABLE: "true"
       KAFKA_CFG_LOG_RETENTION_HOURS: 2
     logging:

--- a/docker-compose-ppm-nsv.yml
+++ b/docker-compose-ppm-nsv.yml
@@ -31,6 +31,58 @@ services:
         max-size: "10m"  
         max-file: "5"
 
+  kafka_init:
+    image: bitnami/kafka:latest
+    depends_on:
+      - kafka
+    entrypoint: ["/bin/sh", "-c"]
+    command: |
+      "
+      sleep 2s
+      /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --list
+      echo 'Creating kafka topics'
+
+      # Create topics
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeBsmPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.FilteredOdeSpatJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatRxJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatRxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeBsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.FilteredOdeBsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeTimJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeTimBroadcastJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.J2735TimBroadcastJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeDriverAlertJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1DecoderInput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1DecoderOutput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1EncoderInput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1EncoderOutput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.SDWDepositorInput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeTIMCertExpirationTimeJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedBSMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedSPATJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedTIMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedMAPJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeMapTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeMapJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedSSMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSsmPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedSRMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSrmTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSrmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedPSMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdePsmTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdePsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+
+      echo 'Kafka created with the following topics:'
+      /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --list
+      exit
+      "
+
   ode:
     build: .
     image: jpoode_ode:latest
@@ -71,6 +123,7 @@ services:
       - kafka
     volumes:
       - ${DOCKER_SHARED_VOLUME}/adm:/asn1_codec_share
+    restart: on-failure
 
   aem:
     build: ./asn1_codec
@@ -105,6 +158,7 @@ services:
       - ${DOCKER_SHARED_VOLUME}/ppm_bsm:/ppm_data
     depends_on:
       - kafka
+    restart: on-failure
 
   ppm_tim:
     build:

--- a/docker-compose-ppm-nsv.yml
+++ b/docker-compose-ppm-nsv.yml
@@ -32,54 +32,11 @@ services:
   kafka_init:
     image: bitnami/kafka:latest
     depends_on:
-      - kafka
-    entrypoint: ["/bin/sh", "-c"]
-    command: |
-      "
-      sleep 2s
-      /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --list
-      echo 'Creating kafka topics'
-
-      # Create topics
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeBsmPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.FilteredOdeSpatJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatRxJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatRxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeBsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.FilteredOdeBsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeTimJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeTimBroadcastJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.J2735TimBroadcastJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeDriverAlertJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1DecoderInput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1DecoderOutput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1EncoderInput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1EncoderOutput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.SDWDepositorInput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeTIMCertExpirationTimeJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedBSMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedSPATJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedTIMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedMAPJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeMapTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeMapJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedSSMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSsmPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedSRMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSrmTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSrmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedPSMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdePsmTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdePsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-
-      echo 'Kafka created with the following topics:'
-      /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --list
-      exit
-      "
+      kafka:
+        condition: service_started
+    volumes:
+      - ./scripts/kafka/kafka_init.sh:/kafka_init.sh
+    entrypoint: ["/bin/sh", "kafka_init.sh"]
 
   ode:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,54 +28,11 @@ services:
   kafka_init:
     image: bitnami/kafka:latest
     depends_on:
-      - kafka
-    entrypoint: ["/bin/sh", "-c"]
-    command: |
-      "
-      sleep 2s
-      /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --list
-      echo 'Creating kafka topics'
-
-      # Create topics
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeBsmPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.FilteredOdeSpatJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatRxJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatRxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeBsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.FilteredOdeBsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeTimJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeTimBroadcastJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.J2735TimBroadcastJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeDriverAlertJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1DecoderInput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1DecoderOutput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1EncoderInput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1EncoderOutput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.SDWDepositorInput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeTIMCertExpirationTimeJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedBSMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedSPATJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedTIMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedMAPJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeMapTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeMapJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedSSMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSsmPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedSRMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSrmTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSrmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedPSMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdePsmTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdePsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
-
-      echo 'Kafka created with the following topics:'
-      /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --list
-      exit
-      "
+      kafka:
+        condition: service_started
+    volumes:
+      - ./scripts/kafka/kafka_init.sh:/kafka_init.sh
+    entrypoint: ["/bin/sh", "kafka_init.sh"]
 
   ode:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,14 +18,64 @@ services:
       KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"
       ALLOW_PLAINTEXT_LISTENER: "yes"
       KAFKA_CFG_NODE_ID: "1"
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
-      KAFKA_CREATE_TOPICS: "topic.OdeBsmPojo:1:1,topic.OdeSpatTxPojo:1:1,topic.OdeSpatPojo:1:1,topic.OdeSpatJson:1:1,topic.FilteredOdeSpatJson:1:1,topic.OdeSpatRxJson:1:1,topic.OdeSpatRxPojo:1:1,topic.OdeBsmJson:1:1,topic.FilteredOdeBsmJson:1:1,topic.OdeTimJson:1:1,topic.OdeTimBroadcastJson:1:1,topic.J2735TimBroadcastJson:1:1,topic.OdeDriverAlertJson:1:1,topic.Asn1DecoderInput:1:1,topic.Asn1DecoderOutput:1:1,topic.Asn1EncoderInput:1:1,topic.Asn1EncoderOutput:1:1,topic.SDWDepositorInput:1:1,topic.OdeTIMCertExpirationTimeJson:1:1,topic.OdeRawEncodedBSMJson:1:1,topic.OdeRawEncodedSPATJson:1:1,topic.OdeRawEncodedTIMJson:1:1,topic.OdeRawEncodedMAPJson:1:1,topic.OdeMapTxPojo:1:1,topic.OdeMapJson:1:1,topic.OdeRawEncodedSSMJson:1:1,topic.OdeSsmPojo:1:1,topic.OdeSsmJson:1:1,topic.OdeRawEncodedSRMJson:1:1,topic.OdeSrmTxPojo:1:1,topic.OdeSrmJson:1:1,topic.OdeRawEncodedPSMJson:1:1,topic.OdePsmTxPojo:1:1,topic.OdePsmJson:1:1"
       KAFKA_CFG_DELETE_TOPIC_ENABLE: "true"
       KAFKA_CFG_LOG_RETENTION_HOURS: 2
     logging:
       options:
         max-size: "10m"  
         max-file: "5"
+
+  kafka_init:
+    image: bitnami/kafka:latest
+    depends_on:
+      - kafka
+    entrypoint: ["/bin/sh", "-c"]
+    command: |
+      "
+      sleep 2s
+      /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --list
+      echo 'Creating kafka topics'
+
+      # Create topics
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeBsmPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.FilteredOdeSpatJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatRxJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatRxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeBsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.FilteredOdeBsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeTimJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeTimBroadcastJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.J2735TimBroadcastJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeDriverAlertJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1DecoderInput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1DecoderOutput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1EncoderInput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1EncoderOutput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.SDWDepositorInput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeTIMCertExpirationTimeJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedBSMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedSPATJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedTIMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedMAPJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeMapTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeMapJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedSSMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSsmPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedSRMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSrmTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSrmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedPSMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdePsmTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdePsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+
+      echo 'Kafka created with the following topics:'
+      /opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --list
+      exit
+      "
 
   ode:
     build: .
@@ -81,6 +131,7 @@ services:
       options:
         max-size: "10m"
         max-file: "5"
+    restart: on-failure
 
   aem:
     build: ./asn1_codec
@@ -99,6 +150,7 @@ services:
       options:
         max-size: "10m"
         max-file: "5"
+    restart: on-failure
 
   ppm_bsm:
     build:

--- a/scripts/kafka/kafka_init.sh
+++ b/scripts/kafka/kafka_init.sh
@@ -1,0 +1,43 @@
+sleep 2s
+/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --list
+echo 'Creating kafka topics'
+
+# Create topics
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeBsmPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.FilteredOdeSpatJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatRxJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSpatRxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeBsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.FilteredOdeBsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeTimJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeTimBroadcastJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.J2735TimBroadcastJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeDriverAlertJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1DecoderInput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1DecoderOutput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1EncoderInput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.Asn1EncoderOutput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.SDWDepositorInput" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeTIMCertExpirationTimeJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedBSMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedSPATJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedTIMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedMAPJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeMapTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeMapJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedSSMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSsmPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedSRMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSrmTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeSrmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdeRawEncodedPSMJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdePsmTxPojo" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists  --topic "topic.OdePsmJson" --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1
+
+echo 'Kafka created with the following topics:'
+/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --list
+exit


### PR DESCRIPTION
# PR Details
## Description

This PR updates the docker-compose files to include an additional service responsible for creating Kafka topics on startup. 

## Motivation and Context

This change fixes an issue where some topics were not created when running Kafka. Additionally, an on-restart policy has been added to the AEM and ADM so that they will continually try reconnecting until their topic is ready.

## How Has This Been Tested?

This has been tested locally using docker compose.

## Types of changes

- [ X ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
