### PR TITLE
Report authEngineID retrieval failure only if response is received

### DIFF
--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/rsu/RsuDepositor.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/rsu/RsuDepositor.java
@@ -127,14 +127,16 @@ public class RsuDepositor extends Thread {
 							logger.error("Error on RSU SNMP deposit to {}: message already exists at index {}.", curRsu.getRsuTarget(),
 									destIndex);
 						} else {
-							// Misc error, provide context
+							// Misc error
 							logger.error("Error on RSU SNMP deposit to {}: {}", curRsu.getRsuTarget(), "Error code '"
-									+ rsuResponse.getResponse().getErrorStatus() + "' '" + rsuResponse.getResponse().getErrorStatusText()
-									+ "' Request PDU: " + rsuResponse.getRequest() + " Response PDU: " + rsuResponse.getResponse());
+									+ rsuResponse.getResponse().getErrorStatus() + "' '" + rsuResponse.getResponse().getErrorStatusText() + "'");
+							// Log the PDUs involved in the failed deposit
+							logger.debug("PDUs involved in failed RSU SNMP deposit to " + curRsu.getRsuTarget()
+									+ " => Request PDU: " + rsuResponse.getRequest() + " Response PDU: " + rsuResponse.getResponse());
 						}
 
 					}
-					logger.info("TIM deposit response {}", responseList);					
+					logger.info("TIM deposit response {}", responseList);				
 				}
 				Thread.sleep(100);
 			}

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/rsu/RsuDepositor.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/rsu/RsuDepositor.java
@@ -127,9 +127,10 @@ public class RsuDepositor extends Thread {
 							logger.error("Error on RSU SNMP deposit to {}: message already exists at index {}.", curRsu.getRsuTarget(),
 									destIndex);
 						} else {
-							// Misc error
-							logger.error("Error on RSU SNMP deposit to {}: {}", curRsu.getRsuTarget(), "Error code "
-									+ rsuResponse.getResponse().getErrorStatus() + " " + rsuResponse.getResponse().getErrorStatusText());
+							// Misc error, provide context
+							logger.error("Error on RSU SNMP deposit to {}: {}", curRsu.getRsuTarget(), "Error code '"
+									+ rsuResponse.getResponse().getErrorStatus() + "' '" + rsuResponse.getResponse().getErrorStatusText()
+									+ "' Request PDU: " + rsuResponse.getRequest() + " Response PDU: " + rsuResponse.getResponse());
 						}
 
 					}


### PR DESCRIPTION
# PR Details
## Description
### Problem:
We're encountering numerous 'authEngineID is null' errors in our GCP environments. Often, these errors occur when the RSU is unreachable. This overlap between RSU unavailability and the 'authEngineID is null' error complicates identifying genuine authEngineID retrieval failures.

### Solution:
The SnmpSession class has been updated to address this issue. Now, regardless of whether the authoritative engine ID can be retrieved beforehand, a request will always be sent to the RSU. Failure to retrieve the authoritative engine ID will only be logged if we receive a response from the RSU. In instances where the RSU is unreachable, failure to retrieve the authoritative engine ID will not be logged anymore.

### Additional Changes
Upon encountering a miscellaneous error status code from the RSU, context will now be provided in the logs. This includes the request PDU and the response PDU.

## Related Issue
No related GitHub issue.

## Motivation and Context
This change ensures that 'authEngineID is null' errors are only logged if a response is received from the RSU, avoiding unnecessary logging when the RSU is unreachable and facilitating accurate issue identification.

## How Has This Been Tested?
These changes have been deployed to the CDOT dev cluster.

## Types of changes
- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
