### PR TITLE
RSU Serialization Fix

### DIFF
--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/RoadSideUnit.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/RoadSideUnit.java
@@ -18,11 +18,14 @@ package us.dot.its.jpo.ode.plugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import us.dot.its.jpo.ode.model.OdeObject;
 
 public class RoadSideUnit {
     public static class RSU extends OdeObject {
 
+        @JsonIgnore
         private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
         private static final long serialVersionUID = 3149576493038209597L;

--- a/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/traveler/TimDepositControllerTest.java
+++ b/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/traveler/TimDepositControllerTest.java
@@ -167,4 +167,11 @@ public class TimDepositControllerTest {
       assertEquals("{\"success\":\"true\"}", actualResponse.getBody());
    }
 
+   @Test
+   public void testSuccessfulRsuMessageReturnsSuccessMessagePost(@Capturing TimTransmogrifier capturingTimTransmogrifier, @Capturing XmlUtils capturingXmlUtils) {
+      String timToSubmit = "{\"request\": {\"rsus\": [{\"latitude\": 30.123456, \"longitude\": -100.12345, \"rsuId\": 123, \"route\": \"myroute\", \"milepost\": 10, \"rsuTarget\": \"172.0.0.1\", \"rsuRetries\": 3, \"rsuTimeout\": 5000, \"rsuIndex\": 7, \"rsuUsername\": \"myusername\", \"rsuPassword\": \"mypassword\"}], \"snmp\": {\"rsuid\": \"83\", \"msgid\": 31, \"mode\": 1, \"channel\": 183, \"interval\": 2000, \"deliverystart\": \"2024-05-13T14:30:00Z\", \"deliverystop\": \"2024-05-13T22:30:00Z\", \"enable\": 1, \"status\": 4}}, \"tim\": {\"msgCnt\": \"1\", \"timeStamp\": \"2024-05-10T19:01:22Z\", \"packetID\": \"123451234512345123\", \"urlB\": \"null\", \"dataframes\": [{\"startDateTime\": \"2024-05-13T20:30:05.014Z\", \"durationTime\": \"30\", \"sspTimRights\": \"1\", \"frameType\": \"advisory\", \"msgId\": {\"roadSignID\": {\"mutcdCode\": \"warning\", \"viewAngle\": \"1111111111111111\", \"position\": {\"latitude\": 30.123456, \"longitude\": -100.12345}}}, \"priority\": \"5\", \"sspLocationRights\": \"1\", \"regions\": [{\"name\": \"I_myroute_RSU_172.0.0.1\", \"anchorPosition\": {\"latitude\": 30.123456, \"longitude\": -100.12345}, \"laneWidth\": \"50\", \"directionality\": \"3\", \"closedPath\": \"false\", \"description\": \"path\", \"path\": {\"scale\": 0, \"nodes\": [{\"delta\": \"node-LL\", \"nodeLat\": 0.0, \"nodeLong\": 0.0}, {\"delta\": \"node-LL\", \"nodeLat\": 0.0, \"nodeLong\": 0.0}], \"type\": \"ll\"}, \"direction\": \"0000000000010000\"}], \"sspMsgTypes\": \"1\", \"sspMsgContent\": \"1\", \"content\": \"workZone\", \"items\": [\"771\"], \"url\": \"null\"}]}}";
+      ResponseEntity<String> actualResponse = testTimDepositController.postTim(timToSubmit);
+      assertEquals("{\"success\":\"true\"}", actualResponse.getBody());
+   }
+
 }


### PR DESCRIPTION
# PR Details
## Description
## Problem
The ODE is running into an infinite recursion error when serializing the RSU class, despite the apparent absence of circular dependencies within it. Jackson attempts to serialize the 'logger' field of the RSU class at this time. The Logger class was likely not intended for serialization and attempting to serialize it causes the error.

## Solution
The 'logger' field of the RSU class now has a JsonIgnore annotation. This instructs Jackson to exclude this field during object serialization.

## Related Issue
No related GitHub issue.

## Motivation and Context
This fix is necessary to ensure proper JSON serialization by the ODE, which is necessary for data flow.

## How Has This Been Tested?
- A unit test has been added to the TimDepositControllerTest class that uses a JSON payload with the 'rsu' element populated to ensure that RSU serialization gets tested. This new test and all others are passing.
- These changes have been deployed to CDOT's dev cluster & the infinite recursion error has been verified to no longer be occurring.

## Types of changes
- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
