### PR TITLE
Log failures to delete messages as errors

### DIFF
--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimDeleteController.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimDeleteController.java
@@ -118,34 +118,42 @@ public class TimDeleteController {
                .body(JsonUtils.jsonKeyValue(ERRSTR, e.getMessage()));
       }
 
-      // Try to explain common errors
-      HttpStatus returnCode = null;
-      String bodyMsg = "";
+      // Provide error codes/text returned from RSU and our interpretation of them
+      HttpStatus httpResponseReturnCode = null;
+      String httpResponseBodyMessage = "";
       if (null == rsuResponse || null == rsuResponse.getResponse()) {
          // Timeout
-         returnCode = HttpStatus.REQUEST_TIMEOUT;
-         bodyMsg = JsonUtils.jsonKeyValue(ERRSTR, "Timeout.");
+         httpResponseReturnCode = HttpStatus.REQUEST_TIMEOUT;
+         String timeoutMessage = "Timeout. No response from RSU.";
+         httpResponseBodyMessage = JsonUtils.jsonKeyValue(ERRSTR, timeoutMessage);
+         logger.error("Failed to delete message at index {} for RSU {}: {}", index, queryTarget, timeoutMessage);
       } else if (rsuResponse.getResponse().getErrorStatus() == 0) {
          // Success
-         returnCode = HttpStatus.OK;
-         bodyMsg = JsonUtils.jsonKeyValue("deleted_msg", Integer.toString(index));
-      } else if (rsuResponse.getResponse().getErrorStatus() == 12) {
-         // Message previously deleted or doesn't exist
-         returnCode = HttpStatus.BAD_REQUEST;
-         bodyMsg = JsonUtils.jsonKeyValue(ERRSTR, "No message at index ".concat(Integer.toString(index)));
-      } else if (rsuResponse.getResponse().getErrorStatus() == 10) {
-         // Invalid index
-         returnCode = HttpStatus.BAD_REQUEST;
-         bodyMsg = JsonUtils.jsonKeyValue(ERRSTR, "Invalid index ".concat(Integer.toString(index)));
+         httpResponseReturnCode = HttpStatus.OK;
+         httpResponseBodyMessage = JsonUtils.jsonKeyValue("deleted_msg", Integer.toString(index));
+         logger.info("Successfully deleted message at index {} for RSU {}", index, queryTarget);
       } else {
-         // Misc error
-         returnCode = HttpStatus.BAD_REQUEST;
-         bodyMsg = JsonUtils.jsonKeyValue(ERRSTR, rsuResponse.getResponse().getErrorStatusText());
+         // Error
+         httpResponseReturnCode = HttpStatus.BAD_REQUEST;
+         int errorCodeReturnedByRSU = rsuResponse.getResponse().getErrorStatus();
+         String errorTextReturnedByRSU = rsuResponse.getResponse().getErrorStatusText();
+         String givenReason = "Error code " + Integer.toString(errorCodeReturnedByRSU) + ": " + errorTextReturnedByRSU;
+         String interpretation = interpretErrorCode(errorCodeReturnedByRSU, index);
+         httpResponseBodyMessage = JsonUtils.jsonKeyValue(ERRSTR, givenReason + " => Interpretation: " + interpretation);
+         logger.error("Failed to delete message at index {} for RSU {} due to error: {} => Interpretation: {}", index, queryTarget, givenReason, interpretation);
       }
 
-      logger.info("Delete call response code: {}, message: {}", returnCode, bodyMsg);
+      return ResponseEntity.status(httpResponseReturnCode).body(httpResponseBodyMessage);
+   }
 
-      return ResponseEntity.status(returnCode).body(bodyMsg);
+   private String interpretErrorCode(int errorCodeReturnedByRSU, int index) {
+      if (errorCodeReturnedByRSU == 12) {
+         return "Message previously deleted or doesn't exist at index " + Integer.toString(index);
+      } else if (errorCodeReturnedByRSU == 10) {
+         return "Invalid index " + Integer.toString(index);
+      } else {
+         return "Unknown error";
+      }
    }
 
 }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimDeleteController.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimDeleteController.java
@@ -121,17 +121,18 @@ public class TimDeleteController {
       // Provide error codes/text returned from RSU and our interpretation of them
       HttpStatus httpResponseReturnCode = null;
       String httpResponseBodyMessage = "";
+      String rsuIpAddress = queryTarget.getRsuTarget();
       if (null == rsuResponse || null == rsuResponse.getResponse()) {
          // Timeout
          httpResponseReturnCode = HttpStatus.REQUEST_TIMEOUT;
          String timeoutMessage = "Timeout. No response from RSU.";
          httpResponseBodyMessage = JsonUtils.jsonKeyValue(ERRSTR, timeoutMessage);
-         logger.error("Failed to delete message at index {} for RSU {}: {}", index, queryTarget, timeoutMessage);
+         logger.error("Failed to delete message at index {} for RSU {}: {}", index, rsuIpAddress, timeoutMessage);
       } else if (rsuResponse.getResponse().getErrorStatus() == 0) {
          // Success
          httpResponseReturnCode = HttpStatus.OK;
          httpResponseBodyMessage = JsonUtils.jsonKeyValue("deleted_msg", Integer.toString(index));
-         logger.info("Successfully deleted message at index {} for RSU {}", index, queryTarget);
+         logger.info("Successfully deleted message at index {} for RSU {}", index, rsuIpAddress);
       } else {
          // Error
          httpResponseReturnCode = HttpStatus.BAD_REQUEST;
@@ -140,7 +141,7 @@ public class TimDeleteController {
          String givenReason = "Error code " + Integer.toString(errorCodeReturnedByRSU) + ": " + errorTextReturnedByRSU;
          String interpretation = interpretErrorCode(errorCodeReturnedByRSU, index);
          httpResponseBodyMessage = JsonUtils.jsonKeyValue(ERRSTR, givenReason + " => Interpretation: " + interpretation);
-         logger.error("Failed to delete message at index {} for RSU {} due to error: {} => Interpretation: {}", index, queryTarget, givenReason, interpretation);
+         logger.error("Failed to delete message at index {} for RSU {} due to error: {} => Interpretation: {}", index, rsuIpAddress, givenReason, interpretation);
       }
 
       return ResponseEntity.status(httpResponseReturnCode).body(httpResponseBodyMessage);


### PR DESCRIPTION
# PR Details
## Description
### Problem
The TimDeleteController at this time does not log failures to delete messages at the 'error' level. Instead, each response for a request is logged at the 'info' level. This means that when verbose logging is disabled, failures to delete messages are essentially silent errors.

### Solution
The TimDeleteController has been modified to log failures to delete messages at the 'error' level and to only log successes at the 'info' level.

### Additional Changes
The error handling in the TimDeleteController was further improved by logging the error codes/text received from the RSU as well as the ODE's interpretation of them.

## Related Issue
N/A

## Motivation and Context
The ODE should not fail silently when it fails to delete a message. Further, a distinction should be made between the RSU's response & our interpretation of it.

## How Has This Been Tested?
- Unit tests have been verified to pass with these changes.
- These changes have been deployed to CDOT's GCP dev environment and logging has been verified to work as expected.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ / ] Defect fix (non-breaking change that fixes an issue)
- [ / ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
