### PR TITLE
Changed version to 2.1.0-SNAPSHOT

### DIFF
--- a/jpo-ode-common/pom.xml
+++ b/jpo-ode-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-ode</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>jpo-ode-common</artifactId>

--- a/jpo-ode-core/pom.xml
+++ b/jpo-ode-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-ode</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jpo-ode-core</artifactId>
@@ -23,12 +23,12 @@
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-common</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-plugins</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/jpo-ode-plugins/pom.xml
+++ b/jpo-ode-plugins/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-ode</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   <properties>
     <!-- SonarQube Properties -->
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-common</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.1.0-SNAPSHOT</version>
     </dependency>
     <!-- TODO open-ode
     <dependency>

--- a/jpo-ode-svcs/pom.xml
+++ b/jpo-ode-svcs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-ode</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>jpo-ode-svcs</artifactId>
   <packaging>jar</packaging>
@@ -102,12 +102,12 @@
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-core</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-plugins</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/jpo-ode-svcs/run.bat
+++ b/jpo-ode-svcs/run.bat
@@ -1,1 +1,1 @@
-java -jar target\jpo-ode-svcs-2.0.0-SNAPSHOT.jar 
+java -jar target\jpo-ode-svcs-2.1.0-SNAPSHOT.jar 

--- a/jpo-ode-svcs/run.sh
+++ b/jpo-ode-svcs/run.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-java -jar target/jpo-ode-svcs-2.0.0-SNAPSHOT.jar 
+java -jar target/jpo-ode-svcs-2.1.0-SNAPSHOT.jar 

--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,12 @@
 
   <scm>
     <developerConnection>scm:git:https://github.com/usdot-jpo-ode/jpo-ode.git</developerConnection>
-    <tag>jpo-ode-2.0.0-SNAPSHOT</tag>
+    <tag>jpo-ode-2.1.0-SNAPSHOT</tag>
   </scm>
 
   <groupId>usdot.jpo.ode</groupId>
   <artifactId>jpo-ode</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>jpo-ode-common</module>


### PR DESCRIPTION
# PR Details
## Description
The version of the project has been changed to 2.1.0-SNAPSHOT in anticipation for the 2024 Q2 Release.

## Related Issue
No related GitHub issue.

## Motivation and Context
The version will need to be updated for the upcoming release and the sooner we do it the less we have to worry about bottleneck during the pom.xml reference updates for the projects.

## How Has This Been Tested?
- The program has been verified to compile with these changes.
- The unit tests have been verified to pass with these changes.

## Types of changes
- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)
- [x] Version change

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
