### PR TITLE
Correct comment in sample.env for KAFKA_TYPE env var

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -51,10 +51,10 @@ DEFAULT_SNMP_PROTOCOL=
 #########################
 # Kafka and Confluent Cloud Properties
 
-# The IP address of Docker host machine which can be found by running "ifconfig"
+# The type of Kafka broker to connect to. If set to "CONFLUENT", the broker will be Confluent Cloud. Otherwise, it will be a local Kafka broker.
 KAFKA_TYPE=
 
-# Confluent Cloud API access credentials
+# Confluent Cloud API access credentials (only required if KAFKA_TYPE is set to "CONFLUENT")
 CONFLUENT_KEY=
 CONFLUENT_SECRET=
 


### PR DESCRIPTION
# PR Details
## Description
### Problem
The comment associated with the KAFKA_TYPE environment variable is incorrect and misleading at this time.

### Solution
The comment associated with the KAFKA_TYPE environment variable has been corrected.

## Related Issue
No related GitHub issue.

## Motivation and Context
Comments associated with environment variables should be accurate and not misleading.

## How Has This Been Tested?
Change to documentation, no testing necessary.

## Types of changes
- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)
- [x] Documentation change

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
