### PR TITLE
Improve SNMP Error Code 10 Interpretation

### DIFF
--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/rsu/RsuDepositor.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/rsu/RsuDepositor.java
@@ -104,6 +104,9 @@ public class RsuDepositor extends Thread {
 							} else if (rsuResponse.getResponse().getErrorStatus() == 5) {
 								// Error, message already exists
 								httpResponseStatus = "Message already exists at ".concat(Integer.toString(curRsu.getRsuIndex()));
+							} else if (rsuResponse.getResponse().getErrorStatus() == 10) {
+								// Error, possible SNMP protocol mismatch
+								httpResponseStatus = "Possible SNMP protocol mismatch, check RSU configuration";
 							} else {
 								// Misc error
 								httpResponseStatus = "Error code " + rsuResponse.getResponse().getErrorStatus() + " "
@@ -128,6 +131,10 @@ public class RsuDepositor extends Thread {
 							Integer destIndex = curRsu.getRsuIndex();
 							logger.error("Error on RSU SNMP deposit to {}: message already exists at index {}.", curRsu.getRsuTarget(),
 									destIndex);
+						} else if (rsuResponse.getResponse().getErrorStatus() == 10) {
+							// Error, possible SNMP protocol mismatch
+							logger.error("Error on RSU SNMP deposit to {}: Possible SNMP protocol mismatch, check RSU configuration.",
+									curRsu.getRsuTarget());
 						} else {
 							// Misc error
 							logger.error("Error on RSU SNMP deposit to {}: {}", curRsu.getRsuTarget(), "Error code '"

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimDeleteController.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimDeleteController.java
@@ -151,7 +151,7 @@ public class TimDeleteController {
       if (errorCodeReturnedByRSU == 12) {
          return "Message previously deleted or doesn't exist at index " + Integer.toString(index);
       } else if (errorCodeReturnedByRSU == 10) {
-         return "Invalid index " + Integer.toString(index);
+         return "Possible SNMP protocol mismatch, check RSU configuration";
       } else {
          return "Unknown error";
       }


### PR DESCRIPTION
## Problem
For deposits, we don't have an interpretation of the 'error code 10 wrong value' issue that can occur when running SNMP commands against an RSU. For deletes, the interpretation is cryptic and offers little guidance.

## Solution
The ODE will now interpret failed deposits/deletes due to 'error code 10 wrong value' as a possible SNMP protocol mismatch and will inform the user to check the RSU configuration.

## Testing
The unit tests have been verified to pass with these changes.