### PR TITLE
Print stack trace upon receiving bad encoded data from ACM only if debug logging is enabled

### DIFF
--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/Asn1EncodedDataRouter.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/Asn1EncodedDataRouter.java
@@ -134,8 +134,16 @@ public class Asn1EncodedDataRouter extends AbstractSubscriberProcessor<String, S
          }
       } catch (Exception e) {
          String msg = "Error in processing received message from ASN.1 Encoder module: " + consumedData;
-         EventLogger.logger.error(msg, e);
-         logger.error(msg, e);
+         if (logger.isDebugEnabled()) {
+            // print error message and stack trace
+            EventLogger.logger.error(msg, e);
+            logger.error(msg, e);
+         }
+         else {
+            // print error message only
+            EventLogger.logger.error(msg);
+            logger.error(msg);
+         }
       }
       return null;
    }


### PR DESCRIPTION
## Problem
The ODE will sometimes receive bad encoded data from the ACM (often due to the ACM running into a problem during processing) and at this time the ODE prints a stack trace regardless of the log level.

## Solution
The Asn1EncodedDataRouter has been modified to print a stack trace in this case only if debug logging is enabled.