### PR TITLE
Fixed dev container build failure

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,25 +10,25 @@ FROM eclipse-temurin:21-jdk
 # will be updated to match your local UID/GID (when using the dockerFile property).
 # See https://aka.ms/vscode-remote/containers/non-root-user for details.
 ARG USERNAME=vscode
-ARG USER_UID=1000
+ARG USER_UID=1234
 ARG USER_GID=$USER_UID
 
 # Configure apt
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
-    #
-    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
-    && groupadd --gid $USER_GID $USERNAME \
-    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    # [Optional] Add sudo support for the non-root user
-    && apt-get install -y sudo \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
-    && chmod 0440 /etc/sudoers.d/$USERNAME \
-    #
-    # Verify git, needed tools installed
-    && apt-get -y install git openssh-client less iproute2 procps curl lsb-release zip unzip sed kafkacat telnet
+RUN apt-get update 
+RUN apt-get upgrade -y 
+RUN apt-get -y install --no-install-recommends apt-utils dialog 2>&1 
+
+# Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+RUN groupadd --gid $USER_GID $USERNAME 
+RUN useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME 
+# [Optional] Add sudo support for the non-root user
+RUN apt-get install -y sudo 
+RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME
+RUN chmod 0440 /etc/sudoers.d/$USERNAME 
+
+# Verify git, needed tools installed
+RUN apt-get -y install git openssh-client less iproute2 procps curl lsb-release zip unzip sed kafkacat telnet
 
 #-------------------Install SDKMan----------------------------------
 RUN curl -s https://get.sdkman.io | bash


### PR DESCRIPTION
# PR Details
## Description
### Problem
The dev container is currently failing to build during the step where the user is added due to the unique ID of 1000 already being taken.

### Solution
The unique ID for the user has been changed to 1234 instead of 1000.

Additionally, a large multi-line step has been broken up into multiple steps. This will make it easier to see where the build failure is in the future.

## Related Issue
No related GitHub issue.

## Motivation and Context
The dev container should not fail to build.

## How Has This Been Tested?
The Dockerfile for the dev container has been verified to work with `docker build . --no-cache`, and reopening the project in the dev container through VSCode has also been verified to work.

## Types of changes
- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
