### PR TITLE
Set SDW_SUBSCRIPTION_TOPIC to 'topic.SDWDepositorInput'

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -76,7 +76,7 @@ CONFLUENT_SECRET=
 ## Required if using SDX depositor module (REST interface)
 SDW_API_KEY=
 SDW_DESTINATION_URL=https://sdx-service.trihydro.com/api/deposit-multi
-SDW_SUBSCRIPTION_TOPIC=topic.J2735TimBroadcastJson
+SDW_SUBSCRIPTION_TOPIC=topic.SDWDepositorInput
 
 ## Optional overrides
 SDW_EMAIL_LIST=error@email.com,test@test.com


### PR DESCRIPTION
## Problem
In the sample.env file, the SDW_SUBSCRIPTION_TOPIC environment variable is incorrectly set to a TIM output topic instead of the 'topic.SDWDepositorInput' topic, which is defined in `jpo-ode-svcs\src\main\java\us\dot\its\jpo\ode\OdeProperties.java`. As a result, the default configuration for the ODE will not work as intended.

## Solution
The SDW_SUBSCRIPTION_TOPIC environment variable in the sample.env file has now been updated to 'topic.SDWDepositorInput'.