### PR TITLE
ODE JSON Schema Updates

### DIFF
--- a/jpo-ode-core/src/main/resources/schemas/schema-map.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-map.json
@@ -51,6 +51,15 @@
                     "type": "string"
                 },
                 "recordGeneratedBy": {
+                    "enum": [
+                        "TMC",
+                        "OBU",
+                        "RSU",
+                        "TMC_VIA_SAT",
+                        "TMC_VIA_SNMP",
+                        "UNKNOWN",
+                        null
+                    ],
                     "type": [
                         "string",
                         "null"

--- a/jpo-ode-core/src/main/resources/schemas/schema-spat.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-spat.json
@@ -238,21 +238,18 @@
                     "type": "string"
                 },
                 "recordGeneratedBy": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "enum": [
-                                "TMC",
-                                "OBU",
-                                "RSU",
-                                "TMC_VIA_SAT",
-                                "TMC_VIA_SNMP",
-                                "UNKNOWN"
-                            ]
-                        },
-                        {
-                            "type": "null"
-                        }
+                    "enum": [
+                        "TMC",
+                        "OBU",
+                        "RSU",
+                        "TMC_VIA_SAT",
+                        "TMC_VIA_SNMP",
+                        "UNKNOWN",
+                        null
+                    ],
+                    "type": [
+                        "string",
+                        "null"
                     ]
                 },
                 "sanitized": {

--- a/jpo-ode-core/src/main/resources/schemas/schema-srm.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-srm.json
@@ -87,6 +87,15 @@
                     "type": "string"
                 },
                 "recordGeneratedBy": {
+                    "enum": [
+                        "TMC",
+                        "OBU",
+                        "RSU",
+                        "TMC_VIA_SAT",
+                        "TMC_VIA_SNMP",
+                        "UNKNOWN",
+                        null
+                    ],
                     "type": [
                         "string",
                         "null"

--- a/jpo-ode-core/src/main/resources/schemas/schema-srm.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-srm.json
@@ -87,7 +87,10 @@
                     "type": "string"
                 },
                 "recordGeneratedBy": {
-                    "type": "null"
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "sanitized": {
                     "type": "boolean"

--- a/jpo-ode-core/src/main/resources/schemas/schema-ssm.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-ssm.json
@@ -93,6 +93,15 @@
                     "type": "string"
                 },
                 "recordGeneratedBy": {
+                    "enum": [
+                        "TMC",
+                        "OBU",
+                        "RSU",
+                        "TMC_VIA_SAT",
+                        "TMC_VIA_SNMP",
+                        "UNKNOWN",
+                        null
+                    ],
                     "type": [
                         "string",
                         "null"

--- a/jpo-ode-core/src/main/resources/schemas/schema-tim.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-tim.json
@@ -31,7 +31,19 @@
                     "type": "string"
                 },
                 "recordGeneratedBy": {
-                    "type": "string"
+                    "enum": [
+                        "TMC",
+                        "OBU",
+                        "RSU",
+                        "TMC_VIA_SAT",
+                        "TMC_VIA_SNMP",
+                        "UNKNOWN",
+                        null
+                    ],
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "recordType": {
                     "type": "string"


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

Updating the "recordGeneratedBy" schema definition to use the ENUM definition of the field as well as allow null values.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

To fix good SRM type messages going to the DLQ in BigQuery and standardizing the message schemas for this field.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Testing known good messages with the updated schemas and verify that the schema validates the message properly.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
