### PR TITLE
SSM Processing Fix

### DIFF
--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SSMBuilder.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SSMBuilder.java
@@ -27,7 +27,7 @@ public class SSMBuilder {
         JsonNode sequenceNumber = SSMMessage.get("sequenceNumber");
 		if(sequenceNumber != null)
 		{
-			genericSSM.setSecond(sequenceNumber.asInt());
+			genericSSM.setSequenceNumber(sequenceNumber.asInt());
 		}
 		
 		JsonNode status = SSMMessage.get("status");

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SignalStatusBuilder.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SignalStatusBuilder.java
@@ -6,45 +6,40 @@ import us.dot.its.jpo.ode.plugin.j2735.J2735SignalStatus;
 import us.dot.its.jpo.ode.plugin.j2735.J2735IntersectionReferenceID;
 
 public class SignalStatusBuilder {
-    private SignalStatusBuilder() {
+	private SignalStatusBuilder() {
 		throw new UnsupportedOperationException();
 	}
 
-    public static J2735SignalStatus genericSignalStatus(JsonNode statusNode) {
-        J2735SignalStatus signalStatus = new J2735SignalStatus();
+	public static J2735SignalStatus genericSignalStatus(JsonNode statusNode) {
+		J2735SignalStatus signalStatus = new J2735SignalStatus();
 
-        JsonNode sequenceNumber = statusNode.get("sequenceNumber");
-		if(sequenceNumber != null)
-		{
+		JsonNode sequenceNumber = statusNode.get("sequenceNumber");
+		if (sequenceNumber != null) {
 			signalStatus.setSequenceNumber(sequenceNumber.asInt());
 		}
 
-        JsonNode statusId = statusNode.get("id");
-		if(statusId != null)
-		{
-            J2735IntersectionReferenceID idObj = new J2735IntersectionReferenceID();
+		JsonNode statusId = statusNode.get("id");
+		if (statusId != null) {
+			J2735IntersectionReferenceID idObj = new J2735IntersectionReferenceID();
 
 			JsonNode region = statusId.get("region");
-			if (region != null)
-			{
+			if (region != null) {
 				idObj.setRegion(region.asInt());
 			}
 
 			JsonNode refId = statusId.get("id");
-			if (refId != null)
-			{
+			if (refId != null) {
 				idObj.setId(refId.asInt());
 			}
 
 			signalStatus.setId(idObj);
 		}
 
-        JsonNode sigStatus = statusNode.get("sigStatus");
-		if(sigStatus != null)
-		{
-			signalStatus.setSigStatus(SignalStatusPackageListBuilder.genericSignalStatusPackageList(sigStatus));				
+		JsonNode sigStatus = statusNode.get("sigStatus");
+		if (sigStatus != null) {
+			signalStatus.setSigStatus(SignalStatusPackageListBuilder.genericSignalStatusPackageList(sigStatus));
 		}
 
-        return signalStatus;
-    }
+		return signalStatus;
+	}
 }

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SignalStatusListBuilder.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SignalStatusListBuilder.java
@@ -14,21 +14,21 @@ public class SignalStatusListBuilder {
 	public static J2735SignalStatusList genericSignalStatusList(JsonNode status) {
 		J2735SignalStatusList signalStatusList = new J2735SignalStatusList();
 
-		if (status.isArray()) {
-			Iterator<JsonNode> elements = status.elements();
-
-			while (elements.hasNext()) {
-				signalStatusList.getStatus()
-                    .add(SignalStatusBuilder.genericSignalStatus(elements.next()));
-			}
-		} else {
-			JsonNode signalStatus = status.get("SignalStatus");
-			if(signalStatus != null)
-			{
-				signalStatusList.getStatus()
-					.add(SignalStatusBuilder.genericSignalStatus(signalStatus));
-			}
-		}
+        JsonNode signalStatus = status.get("SignalStatus");
+        if(signalStatus != null)
+		{
+            if (signalStatus.isArray()) {
+                Iterator<JsonNode> elements = signalStatus.elements();
+    
+                while (elements.hasNext()) {
+                    signalStatusList.getStatus()
+                        .add(SignalStatusBuilder.genericSignalStatus(elements.next()));
+                }
+            } else {
+                signalStatusList.getStatus()
+                        .add(SignalStatusBuilder.genericSignalStatus(signalStatus));
+            }
+        }
 		
 		return signalStatusList;
 	}

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SignalStatusListBuilder.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SignalStatusListBuilder.java
@@ -15,21 +15,22 @@ public class SignalStatusListBuilder {
 		J2735SignalStatusList signalStatusList = new J2735SignalStatusList();
 
         JsonNode signalStatus = status.get("SignalStatus");
-        if(signalStatus != null)
-		{
-            if (signalStatus.isArray()) {
-                Iterator<JsonNode> elements = signalStatus.elements();
-    
-                while (elements.hasNext()) {
-                    signalStatusList.getStatus()
-                        .add(SignalStatusBuilder.genericSignalStatus(elements.next()));
-                }
-            } else {
-                signalStatusList.getStatus()
-                        .add(SignalStatusBuilder.genericSignalStatus(signalStatus));
-            }
+        if(signalStatus == null) {
+            return null;
         }
-		
+
+        if (signalStatus.isArray()) {
+            Iterator<JsonNode> elements = signalStatus.elements();
+
+            while (elements.hasNext()) {
+                signalStatusList.getStatus()
+                    .add(SignalStatusBuilder.genericSignalStatus(elements.next()));
+            }
+        } else {
+            signalStatusList.getStatus()
+                    .add(SignalStatusBuilder.genericSignalStatus(signalStatus));
+        }
+
 		return signalStatusList;
 	}
 }

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SignalStatusPackageListBuilder.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SignalStatusPackageListBuilder.java
@@ -14,22 +14,25 @@ public class SignalStatusPackageListBuilder {
     public static J2735SignalStatusPackageList genericSignalStatusPackageList(JsonNode sigStatus) {
         J2735SignalStatusPackageList signalStatusPackageList = new J2735SignalStatusPackageList();
 
-        if (sigStatus.isArray()) {
-			Iterator<JsonNode> elements = sigStatus.elements();
-
-			while (elements.hasNext()) {
-				signalStatusPackageList.getSigStatus()
-                    .add(SignalStatusPackageBuilder.genericSignalStatusPackage(elements.next()));
-			}
-		} else {
-			JsonNode signalStatusPackage = sigStatus.get("SignalStatusPackage");
-			if(signalStatusPackage != null)
-			{
-				signalStatusPackageList.getSigStatus()
-                	.add(SignalStatusPackageBuilder.genericSignalStatusPackage(signalStatusPackage));
-			}
-
-		}
+        JsonNode signalStatusPackage = sigStatus.get("SignalStatusPackage");
+        if(signalStatusPackage != null)
+        {
+            if (signalStatusPackage.isArray()) {
+                Iterator<JsonNode> elements = signalStatusPackage.elements();
+    
+                while (elements.hasNext()) {
+                    signalStatusPackageList.getSigStatus()
+                        .add(SignalStatusPackageBuilder.genericSignalStatusPackage(elements.next()));
+                }
+            } else {
+                signalStatusPackageList.getSigStatus()
+                        .add(SignalStatusPackageBuilder.genericSignalStatusPackage(signalStatusPackage));
+    
+            }
+        }
+        else {
+            return null;
+        }
 
         return signalStatusPackageList;
     }

--- a/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SignalStatusPackageListBuilder.java
+++ b/jpo-ode-plugins/src/main/java/us/dot/its/jpo/ode/plugin/j2735/builders/SignalStatusPackageListBuilder.java
@@ -15,23 +15,21 @@ public class SignalStatusPackageListBuilder {
         J2735SignalStatusPackageList signalStatusPackageList = new J2735SignalStatusPackageList();
 
         JsonNode signalStatusPackage = sigStatus.get("SignalStatusPackage");
-        if(signalStatusPackage != null)
-        {
-            if (signalStatusPackage.isArray()) {
-                Iterator<JsonNode> elements = signalStatusPackage.elements();
-    
-                while (elements.hasNext()) {
-                    signalStatusPackageList.getSigStatus()
-                        .add(SignalStatusPackageBuilder.genericSignalStatusPackage(elements.next()));
-                }
-            } else {
-                signalStatusPackageList.getSigStatus()
-                        .add(SignalStatusPackageBuilder.genericSignalStatusPackage(signalStatusPackage));
-    
-            }
-        }
-        else {
+        if(signalStatusPackage == null) {
             return null;
+        }
+
+        if (signalStatusPackage.isArray()) {
+            Iterator<JsonNode> elements = signalStatusPackage.elements();
+
+            while (elements.hasNext()) {
+                signalStatusPackageList.getSigStatus()
+                    .add(SignalStatusPackageBuilder.genericSignalStatusPackage(elements.next()));
+            }
+        } else {
+            signalStatusPackageList.getSigStatus()
+                    .add(SignalStatusPackageBuilder.genericSignalStatusPackage(signalStatusPackage));
+
         }
 
         return signalStatusPackageList;

--- a/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/coder/OdeSsmDataCreatorHelperTest.java
+++ b/jpo-ode-svcs/src/test/java/us/dot/its/jpo/ode/coder/OdeSsmDataCreatorHelperTest.java
@@ -1,11 +1,10 @@
 package us.dot.its.jpo.ode.coder;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import org.junit.jupiter.api.Test;
-
-import com.fasterxml.jackson.databind.JsonNode;
 
 import us.dot.its.jpo.ode.model.OdeSsmData;
 import us.dot.its.jpo.ode.util.XmlUtils;
@@ -20,17 +19,19 @@ public class OdeSsmDataCreatorHelperTest {
 
 	@Test
 	public void testCreateOdeSrmData() {
-		String consumedData = "<OdeAsn1Data><metadata><payloadType>us.dot.its.jpo.ode.model.OdeAsn1Payload</payloadType><serialId><streamId>50b5374e-db5b-410f-84d8-c047b1571190</streamId><bundleSize>1</bundleSize><bundleId>0</bundleId><recordId>0</recordId><serialNumber>0</serialNumber></serialId><odeReceivedAt>2021-10-03T20:00:43.331224Z</odeReceivedAt><schemaVersion>6</schemaVersion><maxDurationTime>0</maxDurationTime><odePacketID/><odeTimStartDateTime/><recordGeneratedAt/><recordGeneratedBy/><sanitized>false</sanitized><logFileName/><recordType>ssmTx</recordType><securityResultCode/><receivedMessageDetails/><encodings><encodings><elementName>unsecuredData</elementName><elementType>MessageFrame</elementType><encodingRule>UPER</encodingRule></encodings></encodings><originIp>172.250.250.77</originIp><ssmSource>RSU</ssmSource></metadata><payload><dataType>MessageFrame</dataType><data><MessageFrame><messageId>30</messageId><value><SignalStatusMessage><second>0</second><status><SignalStatus><sequenceNumber>0</sequenceNumber><id><id>12110</id></id><sigStatus><SignalStatusPackage><requester><id><stationID>2366845094</stationID></id><request>3</request><sequenceNumber>0</sequenceNumber><typeData><role><publicTransport/></role></typeData></requester><inboundOn><lane>23</lane></inboundOn><status><granted/></status></SignalStatusPackage></sigStatus></SignalStatus></status></SignalStatusMessage></value></MessageFrame></data></payload></OdeAsn1Data>";
-		JsonNode jsonMap = null;
+		String consumedData = "<?xml version=\"1.0\"?><OdeAsn1Data><metadata><logFileName/><recordType>ssmTx</recordType><securityResultCode>success</securityResultCode><receivedMessageDetails/><encodings><encodings><elementName>unsecuredData</elementName><elementType>MessageFrame</elementType><encodingRule>UPER</encodingRule></encodings></encodings><payloadType>us.dot.its.jpo.ode.model.OdeAsn1Payload</payloadType><serialId><streamId>75b0ddae-5f6e-403d-ae9d-ec41080bb500</streamId><bundleSize>1</bundleSize><bundleId>0</bundleId><recordId>0</recordId><serialNumber>0</serialNumber></serialId><odeReceivedAt>2024-11-11T21:42:11.755Z</odeReceivedAt><schemaVersion>7</schemaVersion><maxDurationTime>0</maxDurationTime><recordGeneratedAt/><recordGeneratedBy>RSU</recordGeneratedBy><sanitized>false</sanitized><odePacketID/><odeTimStartDateTime/><asn1>001E2366CF218CA0B40010BD4C2896A131B71C0450201685AD512AACB3B0105010402E4C6A805000</asn1><originIp>172.18.0.1</originIp><ssmSource>RSU</ssmSource></metadata><payload><dataType>MessageFrame</dataType><data><MessageFrame><messageId>30</messageId><value><SignalStatusMessage><timeStamp>446241</timeStamp><second>36000</second><sequenceNumber>90</sequenceNumber><status><SignalStatus><sequenceNumber>2</sequenceNumber><id><id>12115</id></id><sigStatus><SignalStatusPackage><requester><id><stationID>2823581127</stationID></id><request>1</request><sequenceNumber>10</sequenceNumber><role><publicTransport/></role></requester><inboundOn><lane>5</lane></inboundOn><duration>41323</duration><status><rejected/></status></SignalStatusPackage><SignalStatusPackage><requester><id><stationID>1435923970</stationID></id><request>10</request><sequenceNumber>1</sequenceNumber><role><publicTransport/></role></requester><inboundOn><lane>5</lane></inboundOn><duration>51597</duration><status><rejected/></status></SignalStatusPackage></sigStatus></SignalStatus></status></SignalStatusMessage></value></MessageFrame></data></payload></OdeAsn1Data>";
 		try {
-			jsonMap = XmlUtils.toObjectNode(consumedData);
+			XmlUtils.toObjectNode(consumedData);
 		} catch (XmlUtilsException e) {
 			fail("XML parsing error:" + e);
 		}
+
+		String expectedJson = "{\"metadata\":{\"logFileName\":\"\",\"recordType\":\"ssmTx\",\"securityResultCode\":\"success\",\"receivedMessageDetails\":{\"rxSource\":\"NA\"},\"payloadType\":\"us.dot.its.jpo.ode.model.OdeSsmPayload\",\"serialId\":{\"streamId\":\"75b0ddae-5f6e-403d-ae9d-ec41080bb500\",\"bundleSize\":1,\"bundleId\":0,\"recordId\":0,\"serialNumber\":0},\"odeReceivedAt\":\"2024-11-11T21:42:11.755Z\",\"schemaVersion\":7,\"maxDurationTime\":0,\"recordGeneratedAt\":\"\",\"recordGeneratedBy\":\"RSU\",\"sanitized\":false,\"odePacketID\":\"\",\"odeTimStartDateTime\":\"\",\"asn1\":\"001E2366CF218CA0B40010BD4C2896A131B71C0450201685AD512AACB3B0105010402E4C6A805000\",\"originIp\":\"172.18.0.1\",\"ssmSource\":\"RSU\"},\"payload\":{\"data\":{\"timeStamp\":446241,\"second\":36000,\"sequenceNumber\":90,\"status\":{\"signalStatus\":[{\"sequenceNumber\":2,\"id\":{\"id\":12115},\"sigStatus\":{\"signalStatusPackage\":[{\"requester\":{\"id\":{\"stationID\":2823581127},\"request\":1,\"sequenceNumber\":10,\"role\":\"publicTransport\"},\"inboundOn\":{\"lane\":5},\"duration\":41323,\"status\":\"rejected\"},{\"requester\":{\"id\":{\"stationID\":1435923970},\"request\":10,\"sequenceNumber\":1,\"role\":\"publicTransport\"},\"inboundOn\":{\"lane\":5},\"duration\":51597,\"status\":\"rejected\"}]}}]}},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735SSM\"}}";
 		OdeSsmData ssmData;
 		try {
 			ssmData = OdeSsmDataCreatorHelper.createOdeSsmData(consumedData);
 			assertNotNull(ssmData);
+			assertEquals(ssmData.toJson(), expectedJson);
 		} catch (XmlUtilsException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This resolves issues with how arrays and certain fields were handled in parsing the ASN1 Codec's XML for SSM messages.

The following fields were addressed:
- payload.data.sequenceNumber
- payload.data.status.signalStatus
- payload.data.status.signalStatus.sigStatus.signalStatusPackage

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No related USDOT issue

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
SSM messages are not currently being processed correctly and result in malformed SSM JSON being written to the topic.OdeSsmJson Kafka topic. This is a problem for all data analysts that need accurate SSM data for their reports.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested with real SSM data from the CDOT Region 1 snowplows.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
