### PR TITLE
Switching adopt builder to temurin

### DIFF
--- a/.github/workflows/artifact-publish.yml
+++ b/.github/workflows/artifact-publish.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         java-version: '21'
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: Remove snapshot from version
       run: mvn versions:set -DremoveSnapshot


### PR DESCRIPTION


Switched the github jar builder distribution from adopt to temurin. This will fix broken github jar file generation caused by Adopt moving to a new location. https://api.adoptopenjdk.net/ . Temurin is used by other parts of the ODE and is more in line with the current way code is built in docker.