### PR TITLE
BugFix: use correct config value for setting up producers with Confluent Properties

### DIFF
--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/SerializableMessageProducerPool.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/SerializableMessageProducerPool.java
@@ -39,7 +39,7 @@ public class SerializableMessageProducerPool<K, V> extends SerializableObjectPoo
         super();
         this.odeKafkaProperties = odeKafkaProperties;
         this.brokers = odeKafkaProperties.getBrokers();
-        this.type = odeKafkaProperties.getProducer().getType();
+        this.type = odeKafkaProperties.getKafkaType();
         this.partitionerClass = odeKafkaProperties.getProducer().getPartitionerClass();
         init();
     }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/coder/ByteArrayPublisher.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/coder/ByteArrayPublisher.java
@@ -26,7 +26,7 @@ public class ByteArrayPublisher implements MessagePublisher<byte[]> {
 
    public ByteArrayPublisher(OdeKafkaProperties odeKafkaProperties) {
       this.bytesProducer = MessageProducer.defaultByteArrayMessageProducer(
-         odeKafkaProperties.getBrokers(), odeKafkaProperties.getProducer().getType(),
+         odeKafkaProperties.getBrokers(), odeKafkaProperties.getKafkaType(),
          odeKafkaProperties.getDisabledTopics());
 
    }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/coder/FileAsn1CodecPublisher.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/coder/FileAsn1CodecPublisher.java
@@ -42,7 +42,7 @@ public class FileAsn1CodecPublisher {
 
    public FileAsn1CodecPublisher(OdeKafkaProperties odeKafkaProperties, JsonTopics jsonTopics, RawEncodedJsonTopics rawEncodedJsonTopics) {
       StringPublisher messagePub = new StringPublisher(odeKafkaProperties.getBrokers(),
-              odeKafkaProperties.getProducer().getType(),
+              odeKafkaProperties.getKafkaType(),
               odeKafkaProperties.getDisabledTopics());
 
       this.codecPublisher = new LogFileToAsn1CodecPublisher(messagePub, jsonTopics, rawEncodedJsonTopics);

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/Asn1CommandManager.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/Asn1CommandManager.java
@@ -83,7 +83,7 @@ public class Asn1CommandManager {
             this.rsuDepositor = new RsuDepositor(rsuProperties, securityServicesProperties.getIsRsuSigningEnabled());
             this.rsuDepositor.start();
             this.stringMessageProducer = MessageProducer.defaultStringMessageProducer(odeKafkaProperties.getBrokers(),
-                    odeKafkaProperties.getProducer().getType(),
+                    odeKafkaProperties.getKafkaType(),
                     odeKafkaProperties.getDisabledTopics());
             this.depositTopic = sdxDepositorTopics.getInput();
         } catch (Exception e) {

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/Asn1DecodedDataRouter.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/Asn1DecodedDataRouter.java
@@ -50,24 +50,24 @@ public class Asn1DecodedDataRouter extends AbstractSubscriberProcessor<String, S
         this.pojoTopics = pojoTopics;
         this.jsonTopics = jsonTopics;
         this.bsmProducer = new MessageProducer<>(odeKafkaProperties.getBrokers(),
-                odeKafkaProperties.getProducer().getType(),
+                odeKafkaProperties.getKafkaType(),
                 null,
                 OdeBsmSerializer.class.getName(),
                 odeKafkaProperties.getDisabledTopics());
         this.timProducer = MessageProducer.defaultStringMessageProducer(odeKafkaProperties.getBrokers(),
-                odeKafkaProperties.getProducer().getType(),
+                odeKafkaProperties.getKafkaType(),
                 odeKafkaProperties.getDisabledTopics());
         this.spatProducer = MessageProducer.defaultStringMessageProducer(odeKafkaProperties.getBrokers(),
-                odeKafkaProperties.getProducer().getType(),
+                odeKafkaProperties.getKafkaType(),
                 odeKafkaProperties.getDisabledTopics());
         this.ssmProducer = MessageProducer.defaultStringMessageProducer(odeKafkaProperties.getBrokers(),
-                odeKafkaProperties.getProducer().getType(),
+                odeKafkaProperties.getKafkaType(),
                 odeKafkaProperties.getDisabledTopics());
         this.srmProducer = MessageProducer.defaultStringMessageProducer(odeKafkaProperties.getBrokers(),
-                odeKafkaProperties.getProducer().getType(),
+                odeKafkaProperties.getKafkaType(),
                 odeKafkaProperties.getDisabledTopics());
         this.psmProducer = MessageProducer.defaultStringMessageProducer(odeKafkaProperties.getBrokers(),
-                odeKafkaProperties.getProducer().getType(),
+                odeKafkaProperties.getKafkaType(),
                 odeKafkaProperties.getDisabledTopics());
     }
 

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/Asn1EncodedDataRouter.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/Asn1EncodedDataRouter.java
@@ -79,7 +79,7 @@ public class Asn1EncodedDataRouter extends AbstractSubscriberProcessor<String, S
         this.jsonTopics = jsonTopics;
 
         this.stringMsgProducer = MessageProducer.defaultStringMessageProducer(odeKafkaProperties.getBrokers(),
-                odeKafkaProperties.getProducer().getType(),
+                odeKafkaProperties.getKafkaType(),
                 odeKafkaProperties.getDisabledTopics());
 
         this.asn1CommandManager = new Asn1CommandManager(odeKafkaProperties, sdxDepositorTopics, rsuProperties, securityServicesProperties);

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodeBSMJSON.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodeBSMJSON.java
@@ -22,7 +22,7 @@ public class Asn1DecodeBSMJSON extends AbstractAsn1DecodeMessageJSON {
 	public Asn1DecodeBSMJSON(OdeKafkaProperties odeKafkaProperties, String publishTopic) {
 		super(
 				publishTopic,
-				new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getProducer().getType(), odeKafkaProperties.getDisabledTopics()),
+				new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getKafkaType(), odeKafkaProperties.getDisabledTopics()),
 				SupportedMessageType.BSM.getStartFlag()
 		);
 	}

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodePSMJSON.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodePSMJSON.java
@@ -22,7 +22,7 @@ public class Asn1DecodePSMJSON extends AbstractAsn1DecodeMessageJSON {
 	public Asn1DecodePSMJSON(OdeKafkaProperties odeKafkaProperties, String publishTopic) {
 		super(
 				publishTopic,
-				new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getProducer().getType(), odeKafkaProperties.getDisabledTopics()),
+				new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getKafkaType(), odeKafkaProperties.getDisabledTopics()),
 				SupportedMessageType.PSM.getStartFlag()
 		);}
 

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodeSPATJSON.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodeSPATJSON.java
@@ -22,7 +22,7 @@ public class Asn1DecodeSPATJSON extends AbstractAsn1DecodeMessageJSON {
 	public Asn1DecodeSPATJSON(OdeKafkaProperties odeKafkaProperties, String publishTopic) {
 		super(
 				publishTopic,
-				new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getProducer().getType(), odeKafkaProperties.getDisabledTopics()),
+				new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getKafkaType(), odeKafkaProperties.getDisabledTopics()),
 				SupportedMessageType.SPAT.getStartFlag()
 		);
 	}

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodeSRMJSON.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodeSRMJSON.java
@@ -22,7 +22,7 @@ public class Asn1DecodeSRMJSON extends AbstractAsn1DecodeMessageJSON {
 	public Asn1DecodeSRMJSON(OdeKafkaProperties odeKafkaProperties, String publishTopic) {
 		super(
 				publishTopic,
-				new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getProducer().getType(), odeKafkaProperties.getDisabledTopics()),
+				new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getKafkaType(), odeKafkaProperties.getDisabledTopics()),
 				SupportedMessageType.SRM.getStartFlag()
 		);}
 

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodeSSMJSON.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodeSSMJSON.java
@@ -22,7 +22,7 @@ public class Asn1DecodeSSMJSON extends AbstractAsn1DecodeMessageJSON {
 	public Asn1DecodeSSMJSON(OdeKafkaProperties odeKafkaProperties, String publishTopic) {
 		super(
 				publishTopic,
-				new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getProducer().getType(), odeKafkaProperties.getDisabledTopics()),
+				new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getKafkaType(), odeKafkaProperties.getDisabledTopics()),
 				SupportedMessageType.SSM.getStartFlag()
 		);}
 

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodeTIMJSON.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/message/Asn1DecodeTIMJSON.java
@@ -22,7 +22,7 @@ public class Asn1DecodeTIMJSON extends AbstractAsn1DecodeMessageJSON {
     public Asn1DecodeTIMJSON(OdeKafkaProperties odeKafkaProperties, String publishTopic) {
         super(
                 publishTopic,
-                new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getProducer().getType(), odeKafkaProperties.getDisabledTopics()),
+                new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getKafkaType(), odeKafkaProperties.getDisabledTopics()),
                 SupportedMessageType.TIM.getStartFlag()
         );}
 

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/json/ToJsonConverter.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/json/ToJsonConverter.java
@@ -30,7 +30,7 @@ public class ToJsonConverter<V> extends AbstractSubPubTransformer<String, V, Str
     public ToJsonConverter(OdeKafkaProperties odeKafkaProperties, boolean verbose, String outTopic) {
         super(MessageProducer.defaultStringMessageProducer(
            odeKafkaProperties.getBrokers(),
-           odeKafkaProperties.getProducer().getType(),
+           odeKafkaProperties.getKafkaType(),
            odeKafkaProperties.getDisabledTopics()), outTopic);
         this.verbose = verbose;
     }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimDepositController.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/traveler/TimDepositController.java
@@ -100,8 +100,8 @@ public class TimDepositController {
         this.serialIdOde = new SerialId();
 
         this.stringMsgProducer = MessageProducer.defaultStringMessageProducer(odeKafkaProperties.getBrokers(),
-                odeKafkaProperties.getProducer().getType(), odeKafkaProperties.getDisabledTopics());
-        this.timProducer = new MessageProducer<>(odeKafkaProperties.getBrokers(), odeKafkaProperties.getProducer().getType(),
+                odeKafkaProperties.getKafkaType(), odeKafkaProperties.getDisabledTopics());
+        this.timProducer = new MessageProducer<>(odeKafkaProperties.getBrokers(), odeKafkaProperties.getKafkaType(),
                 null, OdeTimSerializer.class.getName(), odeKafkaProperties.getDisabledTopics());
 
         this.dataSigningEnabledSDW = securityServicesProperties.getIsSdwSigningEnabled();

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/bsm/BsmReceiver.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/bsm/BsmReceiver.java
@@ -20,7 +20,7 @@ public class BsmReceiver extends AbstractUdpReceiverPublisher {
         super(receiverProperties.getReceiverPort(), receiverProperties.getBufferSize());
 
         this.publishTopic = publishTopic;
-        this.bsmPublisher = new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getProducer().getType(), odeKafkaProperties.getDisabledTopics());
+        this.bsmPublisher = new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getKafkaType(), odeKafkaProperties.getDisabledTopics());
     }
 
     @Override

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/generic/GenericReceiver.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/generic/GenericReceiver.java
@@ -22,7 +22,7 @@ public class GenericReceiver extends AbstractUdpReceiverPublisher {
     public GenericReceiver(UDPReceiverProperties.ReceiverProperties props, OdeKafkaProperties odeKafkaProperties, RawEncodedJsonTopics rawEncodedJsonTopics) {
         super(props.getReceiverPort(), props.getBufferSize());
 
-        this.publisher = new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getProducer().getType(), odeKafkaProperties.getDisabledTopics());
+        this.publisher = new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getKafkaType(), odeKafkaProperties.getDisabledTopics());
         this.rawEncodedJsonTopics = rawEncodedJsonTopics;
     }
 

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/psm/PsmReceiver.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/psm/PsmReceiver.java
@@ -20,7 +20,7 @@ public class PsmReceiver extends AbstractUdpReceiverPublisher {
         super(receiverProperties.getReceiverPort(), receiverProperties.getBufferSize());
 
         this.publishTopic = publishTopic;
-        this.psmPublisher = new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getProducer().getType(), odeKafkaProperties.getDisabledTopics());
+        this.psmPublisher = new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getKafkaType(), odeKafkaProperties.getDisabledTopics());
     }
 
     @Override

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/spat/SpatReceiver.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/spat/SpatReceiver.java
@@ -20,7 +20,7 @@ public class SpatReceiver extends AbstractUdpReceiverPublisher {
         super(receiverProperties.getReceiverPort(), receiverProperties.getBufferSize());
 
         this.publishTopic = publishTopic;
-        this.spatPublisher = new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getProducer().getType(), odeKafkaProperties.getDisabledTopics());
+        this.spatPublisher = new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getKafkaType(), odeKafkaProperties.getDisabledTopics());
     }
 
     @Override

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/srm/SrmReceiver.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/srm/SrmReceiver.java
@@ -20,7 +20,7 @@ public class SrmReceiver extends AbstractUdpReceiverPublisher {
         super(receiverProperties.getReceiverPort(), receiverProperties.getBufferSize());
 
         this.publishTopic = publishTopic;
-        this.srmPublisher = new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getProducer().getType(), odeKafkaProperties.getDisabledTopics());
+        this.srmPublisher = new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getKafkaType(), odeKafkaProperties.getDisabledTopics());
     }
 
     @Override

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/ssm/SsmReceiver.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/ssm/SsmReceiver.java
@@ -20,7 +20,7 @@ public class SsmReceiver extends AbstractUdpReceiverPublisher {
         super(receiverProperties.getReceiverPort(), receiverProperties.getBufferSize());
 
         this.publishTopic = publishTopic;
-        this.ssmPublisher = new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getProducer().getType(), odeKafkaProperties.getDisabledTopics());
+        this.ssmPublisher = new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getKafkaType(), odeKafkaProperties.getDisabledTopics());
     }
 
     @Override

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/tim/TimReceiver.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/tim/TimReceiver.java
@@ -20,7 +20,7 @@ public class TimReceiver extends AbstractUdpReceiverPublisher {
         super(receiverProperties.getReceiverPort(), receiverProperties.getBufferSize());
 
         this.publishTopic = publishTopic;
-        this.timPublisher = new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getProducer().getType(), odeKafkaProperties.getDisabledTopics());
+        this.timPublisher = new StringPublisher(odeKafkaProperties.getBrokers(), odeKafkaProperties.getKafkaType(), odeKafkaProperties.getDisabledTopics());
     }
 
     @Override


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Use the correct configuration value to drive the StringProducer creation. Previously was using the Producer Type where we should be using the Kafka Type. This mismatch caused the code not to set the Confluent properties on the StringProducers, so they couldn't connect to Confluent.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
See description

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

@Michael7371 and I built and deployed this to the CDOT dev environment to confirm that the producers could connect and produce to the respective queues.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
