### PR TITLE
style: remove warnings for missing paragraph tags in checkstyle.xml

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -317,7 +317,9 @@
       <property name="forbiddenSummaryFragments"
         value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
     </module>
+    <!--  We found little benefit to this rule. We disabled to prevent useless warnings on license headers.
     <module name="JavadocParagraph"/>
+    -->
     <module name="RequireEmptyLineBeforeBlockTagGroup"/>
     <module name="AtclauseOrder">
       <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Disable CheckStyle warnings for missing paragraph tags in our Javadocs.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Many warnings/violations were reported on our files with license headers. We find no benefit to enforcing paragraph tag format in our Javadocs and license headers (in Javadoc format), so we are disabling this warning.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I confirmed that [StringPublisher](https://github.com/CDOT-CV/jpo-ode/blob/6abb0db6e93f89ddf7e7c0e7bf05b34daba3fd8f/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/coder/StringPublisher.java#L6)'s license header no longer triggers check style warnings even though it violates the paragraph tag rule. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
