### PR TITLE
Updated Submodule Compatibility Guide for 2025 Q1 Release

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -3,6 +3,7 @@ This table serves as a guide, suggesting which versions of individual submodules
 
 | [ODE (this project)](https://github.com/usdot-jpo-ode/jpo-ode/releases) | [ACM](https://github.com/usdot-jpo-ode/asn1_codec/releases) | [PPM](https://github.com/usdot-jpo-ode/jpo-cvdp/releases) | [SEC](https://github.com/usdot-jpo-ode/jpo-security-svcs/releases) | [SDWD](https://github.com/usdot-jpo-ode/jpo-sdw-depositor/releases) | [S3D](https://github.com/usdot-jpo-ode/jpo-s3-deposit/releases) | [GJConverter](https://github.com/usdot-jpo-ode/jpo-geojsonconverter/releases) | [CMonitor](https://github.com/usdot-jpo-ode/jpo-conflictmonitor/releases) | [CVisualizer](https://github.com/usdot-jpo-ode/jpo-conflictvisualizer/releases) | [CVManager](https://github.com/usdot-jpo-ode/jpo-cvmanager/releases) |
 | ----------------- | --- | --- | --- | ---- | --- | ----------- | -------- | ----------- | ----------- |
+| 4.0.0 | 3.0.0 | 1.5.0 | 1.5.0 | 1.9.0 | 1.7.0 | 1.5.0 | 1.5.0 | 1.5.0 | 1.5.0 |
 | 3.0.0 | 2.2.0 | 1.4.0 | 1.5.0 | 1.8.0 | 1.6.0 | 1.4.2 | 1.4.2 | 1.4.1 | 1.4.0 |
 | 2.1.0 | 2.1.0 | 1.3.0 | 1.4.0 | 1.7.0 | 1.5.0 | 1.3.0 | 1.3.0 | 1.3.0 | 1.3.0 |
 | 2.0.x | 2.0.0 | 1.3.0 | 1.4.0 | 1.6.0 | 1.4.0 | 1.2.0 | 1.2.0 | 1.2.0 | 1.2.0 |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -3,7 +3,7 @@ This table serves as a guide, suggesting which versions of individual submodules
 
 | [ODE (this project)](https://github.com/usdot-jpo-ode/jpo-ode/releases) | [ACM](https://github.com/usdot-jpo-ode/asn1_codec/releases) | [PPM](https://github.com/usdot-jpo-ode/jpo-cvdp/releases) | [SEC](https://github.com/usdot-jpo-ode/jpo-security-svcs/releases) | [SDWD](https://github.com/usdot-jpo-ode/jpo-sdw-depositor/releases) | [S3D](https://github.com/usdot-jpo-ode/jpo-s3-deposit/releases) | [GJConverter](https://github.com/usdot-jpo-ode/jpo-geojsonconverter/releases) | [CMonitor](https://github.com/usdot-jpo-ode/jpo-conflictmonitor/releases) | [CVisualizer](https://github.com/usdot-jpo-ode/jpo-conflictvisualizer/releases) | [CVManager](https://github.com/usdot-jpo-ode/jpo-cvmanager/releases) |
 | ----------------- | --- | --- | --- | ---- | --- | ----------- | -------- | ----------- | ----------- |
-| 4.0.0 | 3.0.0 | 1.5.0 | 1.5.0 | 1.9.0 | 1.7.0 | 2.0.0 | 1.5.0 | 1.5.0 | 1.5.0 |
+| 4.0.0 | 3.0.0 | 1.5.0 | 1.5.0 | 1.9.0 | 1.7.0 | 2.0.0 | 2.0.0 | 1.5.0 | 1.5.0 |
 | 3.0.0 | 2.2.0 | 1.4.0 | 1.5.0 | 1.8.0 | 1.6.0 | 1.4.2 | 1.4.2 | 1.4.1 | 1.4.0 |
 | 2.1.0 | 2.1.0 | 1.3.0 | 1.4.0 | 1.7.0 | 1.5.0 | 1.3.0 | 1.3.0 | 1.3.0 | 1.3.0 |
 | 2.0.x | 2.0.0 | 1.3.0 | 1.4.0 | 1.6.0 | 1.4.0 | 1.2.0 | 1.2.0 | 1.2.0 | 1.2.0 |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -3,7 +3,7 @@ This table serves as a guide, suggesting which versions of individual submodules
 
 | [ODE (this project)](https://github.com/usdot-jpo-ode/jpo-ode/releases) | [ACM](https://github.com/usdot-jpo-ode/asn1_codec/releases) | [PPM](https://github.com/usdot-jpo-ode/jpo-cvdp/releases) | [SEC](https://github.com/usdot-jpo-ode/jpo-security-svcs/releases) | [SDWD](https://github.com/usdot-jpo-ode/jpo-sdw-depositor/releases) | [S3D](https://github.com/usdot-jpo-ode/jpo-s3-deposit/releases) | [GJConverter](https://github.com/usdot-jpo-ode/jpo-geojsonconverter/releases) | [CMonitor](https://github.com/usdot-jpo-ode/jpo-conflictmonitor/releases) | [CVisualizer](https://github.com/usdot-jpo-ode/jpo-conflictvisualizer/releases) | [CVManager](https://github.com/usdot-jpo-ode/jpo-cvmanager/releases) |
 | ----------------- | --- | --- | --- | ---- | --- | ----------- | -------- | ----------- | ----------- |
-| 4.0.0 | 3.0.0 | 1.5.0 | 1.5.0 | 1.9.0 | 1.7.0 | 1.5.0 | 1.5.0 | 1.5.0 | 1.5.0 |
+| 4.0.0 | 3.0.0 | 1.5.0 | 1.5.0 | 1.9.0 | 1.7.0 | 2.0.0 | 1.5.0 | 1.5.0 | 1.5.0 |
 | 3.0.0 | 2.2.0 | 1.4.0 | 1.5.0 | 1.8.0 | 1.6.0 | 1.4.2 | 1.4.2 | 1.4.1 | 1.4.0 |
 | 2.1.0 | 2.1.0 | 1.3.0 | 1.4.0 | 1.7.0 | 1.5.0 | 1.3.0 | 1.3.0 | 1.3.0 | 1.3.0 |
 | 2.0.x | 2.0.0 | 1.3.0 | 1.4.0 | 1.6.0 | 1.4.0 | 1.2.0 | 1.2.0 | 1.2.0 | 1.2.0 |


### PR DESCRIPTION
# PR Details
## Description
An entry has been added to the Submodule Compatibility Guide for the 2025 Q1 Release. The following table outlines the actions taken regarding version changes for each project:

| Project | Action | New Version |
| --- | --- | --- |
| jpo-ode | major version incremented | 4.0.0 |
| asn1_codec | major version incremented | 3.0.0 |
| jpo-cvdp | minor version incremented | 1.5.0 |
| jpo-security-svcs | no change | 1.5.0 |
| jpo-sdw-depositor | minor version incremented | 1.9.0 |
| jpo-s3-deposit | minor version incremented | 1.7.0 |
| jpo-geojsonconverter | major version incremented | 2.0.0 |
| jpo-conflictmonitor | major version incremented | 2.0.0 |
| jpo-conflictvisualizer | minor version incremented | 1.5.0 |
| jpo-cvmanager | minor version incremented | 1.5.0 |

## Related Issue
No related GitHub issue.

## Motivation and Context
Updating the Submodule Compatibility Guide is essential for keeping users informed about which versions of each project are compatible with a given version of the jpo-ode project. Since versions are not updated simultaneously, this ensures that users can effectively utilize the ODE.

## How Has This Been Tested?
Documentation change, no testing necessary.

## Types of changes
- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)
- [x] Documentation

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
