### PR TITLE
Resolve TIM schema inconsistency

### DIFF
--- a/jpo-ode-core/src/main/resources/schemas/schema-tim.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-tim.json
@@ -731,78 +731,78 @@
                 {
                     "type": "object",
                     "properties": {
-                        "nodeXY1": {
+                        "node-XY1": {
                             "$ref": "#/$defs/NodeXYPoint"
                         }
                     },
                     "required": [
-                        "nodeXY1"
+                        "node-XY1"
                     ]
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "nodeXY2": {
+                        "node-XY2": {
                             "$ref": "#/$defs/NodeXYPoint"
                         }
                     },
                     "required": [
-                        "nodeXY2"
+                        "node-XY2"
                     ]
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "nodeXY3": {
+                        "node-XY3": {
                             "$ref": "#/$defs/NodeXYPoint"
                         }
                     },
                     "required": [
-                        "nodeXY3"
+                        "node-XY3"
                     ]
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "nodeXY4": {
+                        "node-XY4": {
                             "$ref": "#/$defs/NodeXYPoint"
                         }
                     },
                     "required": [
-                        "nodeXY4"
+                        "node-XY4"
                     ]
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "nodeXY5": {
+                        "node-XY5": {
                             "$ref": "#/$defs/NodeXYPoint"
                         }
                     },
                     "required": [
-                        "nodeXY5"
+                        "node-XY5"
                     ]
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "nodeXY6": {
+                        "node-XY6": {
                             "$ref": "#/$defs/NodeXYPoint"
                         }
                     },
                     "required": [
-                        "nodeXY6"
+                        "node-XY6"
                     ]
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "nodeLatLon": {
+                        "node-LatLon": {
                             "$ref": "#/$defs/NodeLLmD"
                         }
                     },
                     "required": [
-                        "nodeLatLon"
+                        "node-LatLon"
                     ]
                 }
             ]
@@ -992,78 +992,78 @@
                 {
                     "type": "object",
                     "properties": {
-                        "nodeLL1": {
+                        "node-LL1": {
                             "$ref": "#/$defs/NodeLLmD"
                         }
                     },
                     "required": [
-                        "nodeLL1"
+                        "node-LL1"
                     ]
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "nodeLL2": {
+                        "node-LL2": {
                             "$ref": "#/$defs/NodeLLmD"
                         }
                     },
                     "required": [
-                        "nodeLL2"
+                        "node-LL2"
                     ]
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "nodeLL3": {
+                        "node-LL3": {
                             "$ref": "#/$defs/NodeLLmD"
                         }
                     },
                     "required": [
-                        "nodeLL3"
+                        "node-LL3"
                     ]
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "nodeLL4": {
+                        "node-LL4": {
                             "$ref": "#/$defs/NodeLLmD"
                         }
                     },
                     "required": [
-                        "nodeLL4"
+                        "node-LL4"
                     ]
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "nodeLL5": {
+                        "node-LL5": {
                             "$ref": "#/$defs/NodeLLmD"
                         }
                     },
                     "required": [
-                        "nodeLL5"
+                        "node-LL5"
                     ]
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "nodeLL6": {
+                        "node-LL6": {
                             "$ref": "#/$defs/NodeLLmD"
                         }
                     },
                     "required": [
-                        "nodeLL6"
+                        "node-LL6"
                     ]
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "nodeLatLon": {
+                        "node-LatLon": {
                             "$ref": "#/$defs/NodeLLmD"
                         }
                     },
                     "required": [
-                        "nodeLatLon"
+                        "node-LatLon"
                     ]
                 }
             ]


### PR DESCRIPTION
…message field names

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Resolves an issue for the TIM schema wherein the `NodeOffsetPointXY` and `NodeOffsetPointLL` schema objects are missing hyphens in their fields.

Example:
- Was: `nodeXY1`
- Now: `node-XY1`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The previous TIM schema did not accurately portray the output of the jpo-ode 4.0.0 OdeTimJson message which is misleading and fails schema validation checks when the fields are included.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with unit tests and online JSON schema validators.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
