### PR TITLE
Fix: producer failures

### DIFF
--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/kafka/producer/KafkaProducerConfig.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/kafka/producer/KafkaProducerConfig.java
@@ -163,6 +163,10 @@ public class KafkaProducerConfig {
     if ("CONFLUENT".equals(this.odeKafkaProperties.getKafkaType())) {
       producerProps.putAll(this.odeKafkaProperties.getConfluent().buildConfluentProperties());
     }
+    // linger.ms isn't present in the KafkaProperties object above, but it is important to limit the amount of time
+    // we wait before publishing messages via the KafkaTemplate producer while the data size of the batch is less than the
+    // batch-size set in the application.yaml. The default is (2^31)-1 millis, which is not suitable for our use case.
+    producerProps.put("linger.ms", odeKafkaProperties.getProducer().getLingerMs());
     return producerProps;
   }
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Set `linger.ms` to 1 millisecond to prevent producer failures.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
During CDOT GCP dev testing, we encountered many `ERROR LoggingProducerListener - Failed to produce to topic` errors in the logs specifically associated with Spring Kafka-managed producers. This is not ideal

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deployed to CDOT GCP dev and watched the logs to confirm the exceptions were no longer thrown.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
