### PR TITLE
Fix: Use odeKafkaProperties env vars to drive producer retries

### DIFF
--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/kafka/producer/KafkaProducerConfig.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/kafka/producer/KafkaProducerConfig.java
@@ -2,6 +2,7 @@ package us.dot.its.jpo.ode.kafka.producer;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
@@ -166,7 +167,8 @@ public class KafkaProducerConfig {
     // linger.ms isn't present in the KafkaProperties object above, but it is important to limit the amount of time
     // we wait before publishing messages via the KafkaTemplate producer while the data size of the batch is less than the
     // batch-size set in the application.yaml. The default is (2^31)-1 millis, which is not suitable for our use case.
-    producerProps.put("linger.ms", odeKafkaProperties.getProducer().getLingerMs());
+    producerProps.put(ProducerConfig.LINGER_MS_CONFIG, odeKafkaProperties.getProducer().getLingerMs());
+    producerProps.put(ProducerConfig.RETRIES_CONFIG, odeKafkaProperties.getProducer().getRetries());
     return producerProps;
   }
 }

--- a/jpo-ode-svcs/src/main/resources/application.yaml
+++ b/jpo-ode-svcs/src/main/resources/application.yaml
@@ -8,7 +8,6 @@ spring:
       bootstrap-servers: ${ODE_KAFKA_BROKERS}
     producer:
       acks: "all"
-      retries: 2
       batch-size: 16384
       compression-type: "zstd"
       buffer-memory: 33554432


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Use environment variables to drive producer retries for consistency with non-spring kafka producer configurations

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
To keep the Spring Kafka producers and legacy producers configurations consistent.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I spun up the docker compose with profile `all` locally to confirm the environment variables are set correctly and the Spring Kakfa producers are using the same values for retries.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
