### PR TITLE
PSM Schema Fix

### DIFF
--- a/jpo-ode-core/src/main/resources/schemas/schema-psm.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-psm.json
@@ -101,7 +101,19 @@
                     "type": "string"
                 },
                 "recordGeneratedBy": {
-                    "type": "null"
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "enum": [
+                        "TMC",
+                        "OBU",
+                        "RSU",
+                        "TMC_VIA_SAT",
+                        "TMC_VIA_SNMP",
+                        "UNKNOWN",
+                        null
+                    ]
                 },
                 "sanitized": {
                     "type": "boolean"

--- a/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdePsmDataTest.java
+++ b/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdePsmDataTest.java
@@ -17,7 +17,7 @@ public class OdePsmDataTest {
     private static final String ASN1_STRING = "011d0000201a0000021bd86891de75f84da101c13f042e2214141fff00022c2000270000000163b2cc7986010000";
     
     final String json = String.format("{\"metadata\":{\"logFileName\":\"\",\"maxDurationTime\":0,\"odePacketID\":\"\",\"odeReceivedAt\":\"2023-09-21T15:30:14.926500Z\",\"odeTimStartDateTime\":\"\",\"originIp\":\"192.168.16.1\",\"payloadType\":\"us.dot.its.jpo.ode.model.OdePsmPayload\",\"psmSource\":\"RSU\",\"receivedMessageDetails\":{\"rxSource\":\"NA\"},\"recordGeneratedAt\":\"\",\"recordType\":\"psmTx\",\"sanitized\":false,\"schemaVersion\":%s,\"securityResultCode\":\"success\",\"serialId\":{\"bundleId\":0,\"bundleSize\":1,\"recordId\":0,\"serialNumber\":0,\"streamId\":\"06cc1c17-e331-4806-a8ee-456b98c6517b\"},\"asn1\":\"%s\"},\"payload\":{\"data\":{\"accuracy\":{\"orientation\":44.9951935489,\"semiMajor\":1.0,\"semiMinor\":1.0},\"basicType\":\"aPEDESTRIAN\",\"heading\":8898,\"id\":\"24779D7E\",\"msgCnt\":26,\"position\":{\"latitude\":40.2397377,\"longitude\":-74.2761437},\"secMark\":3564,\"speed\":0},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735PSM\"}}", SCHEMA_VERSION, ASN1_STRING);
-
+    
     @Test
     public void shouldDeserializeJson() {
         final var deserialized = (OdePsmData)JsonUtils.fromJson(json, OdePsmData.class);
@@ -46,4 +46,19 @@ public class OdePsmDataTest {
         Set<ValidationMessage> validationMessages = schema.validate(node);
         assertEquals(String.format("Json validation errors: %s", validationMessages), 0, validationMessages.size());
     }
+
+    @Test
+    public void shouldValidateJson_NonNullRecordGeneratedAt() throws Exception {
+        final var deserialized = (OdePsmData)JsonUtils.fromJson(json, OdePsmData.class);
+        deserialized.getMetadata().setRecordGeneratedBy(OdeMsgMetadata.GeneratedBy.UNKNOWN);
+        final String serialized = deserialized.toJson(false);
+
+        // Load json schema from resource
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4);
+        final JsonSchema schema = factory.getSchema(getClass().getClassLoader().getResource("schemas/schema-psm.json").toURI());
+        final JsonNode node = (JsonNode)JsonUtils.fromJson(serialized, JsonNode.class);
+        Set<ValidationMessage> validationMessages = schema.validate(node);
+        assertEquals(String.format("Json validation errors: %s", validationMessages), 0, validationMessages.size());
+    }
+
 }

--- a/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdePsmDataTest.java
+++ b/jpo-ode-core/src/test/java/us/dot/its/jpo/ode/model/OdePsmDataTest.java
@@ -1,64 +1,59 @@
 package us.dot.its.jpo.ode.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
-
 import org.junit.Test;
-import static org.junit.Assert.*;
-
 import us.dot.its.jpo.ode.util.JsonUtils;
 
+/**
+ * Unit test class for OdePsmData.
+ */
 public class OdePsmDataTest {
-    private static final String SCHEMA_VERSION = "8";
-    private static final String ASN1_STRING = "011d0000201a0000021bd86891de75f84da101c13f042e2214141fff00022c2000270000000163b2cc7986010000";
-    
-    final String json = String.format("{\"metadata\":{\"logFileName\":\"\",\"maxDurationTime\":0,\"odePacketID\":\"\",\"odeReceivedAt\":\"2023-09-21T15:30:14.926500Z\",\"odeTimStartDateTime\":\"\",\"originIp\":\"192.168.16.1\",\"payloadType\":\"us.dot.its.jpo.ode.model.OdePsmPayload\",\"psmSource\":\"RSU\",\"receivedMessageDetails\":{\"rxSource\":\"NA\"},\"recordGeneratedAt\":\"\",\"recordType\":\"psmTx\",\"sanitized\":false,\"schemaVersion\":%s,\"securityResultCode\":\"success\",\"serialId\":{\"bundleId\":0,\"bundleSize\":1,\"recordId\":0,\"serialNumber\":0,\"streamId\":\"06cc1c17-e331-4806-a8ee-456b98c6517b\"},\"asn1\":\"%s\"},\"payload\":{\"data\":{\"accuracy\":{\"orientation\":44.9951935489,\"semiMajor\":1.0,\"semiMinor\":1.0},\"basicType\":\"aPEDESTRIAN\",\"heading\":8898,\"id\":\"24779D7E\",\"msgCnt\":26,\"position\":{\"latitude\":40.2397377,\"longitude\":-74.2761437},\"secMark\":3564,\"speed\":0},\"dataType\":\"us.dot.its.jpo.ode.plugin.j2735.J2735PSM\"}}", SCHEMA_VERSION, ASN1_STRING);
-    
-    @Test
-    public void shouldDeserializeJson() {
-        final var deserialized = (OdePsmData)JsonUtils.fromJson(json, OdePsmData.class);
-        assertNotNull(deserialized);
-        assertTrue(deserialized.getMetadata() instanceof OdePsmMetadata);
-        assertTrue(deserialized.getPayload() instanceof OdePsmPayload);
-        
-    }
+  private String loadTestJson() throws IOException {
+    return new String(getClass().getClassLoader()
+        .getResourceAsStream("json/sample-psm.json")
+        .readAllBytes(), StandardCharsets.UTF_8);
+  }
 
-    @Test
-    public void serializationShouldNotAddClassProperty() {
-        final var deserialized = (OdePsmData)JsonUtils.fromJson(json, OdePsmData.class);
-        final String serialized = deserialized.toJson(false);
-        assertFalse(serialized.contains("@class"));
-    }
+  @Test
+  public void shouldDeserializeJson() throws IOException {
+    final var deserialized = (OdePsmData) JsonUtils.fromJson(loadTestJson(), OdePsmData.class);
+    assertNotNull(deserialized);
+    assertTrue(deserialized.getMetadata() instanceof OdePsmMetadata);
+    assertTrue(deserialized.getPayload() instanceof OdePsmPayload);
 
-    @Test
-    public void shouldValidateJson() throws Exception {
-        final var deserialized = (OdePsmData)JsonUtils.fromJson(json, OdePsmData.class);
-        final String serialized = deserialized.toJson(false);
+  }
 
-        // Load json schema from resource
-        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4);
-        final JsonSchema schema = factory.getSchema(getClass().getClassLoader().getResource("schemas/schema-psm.json").toURI());
-        final JsonNode node = (JsonNode)JsonUtils.fromJson(serialized, JsonNode.class);
-        Set<ValidationMessage> validationMessages = schema.validate(node);
-        assertEquals(String.format("Json validation errors: %s", validationMessages), 0, validationMessages.size());
-    }
+  @Test
+  public void serializationShouldNotAddClassProperty() throws IOException  {
+    final var deserialized = (OdePsmData) JsonUtils.fromJson(loadTestJson(), OdePsmData.class);
+    final String serialized = deserialized.toJson(false);
+    assertFalse(serialized.contains("@class"));
+  }
 
-    @Test
-    public void shouldValidateJson_NonNullRecordGeneratedAt() throws Exception {
-        final var deserialized = (OdePsmData)JsonUtils.fromJson(json, OdePsmData.class);
-        deserialized.getMetadata().setRecordGeneratedBy(OdeMsgMetadata.GeneratedBy.UNKNOWN);
-        final String serialized = deserialized.toJson(false);
+  @Test
+  public void shouldValidateJson() throws Exception {
+    final var deserialized = (OdePsmData) JsonUtils.fromJson(loadTestJson(), OdePsmData.class);
+    final String serialized = deserialized.toJson(false);
 
-        // Load json schema from resource
-        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4);
-        final JsonSchema schema = factory.getSchema(getClass().getClassLoader().getResource("schemas/schema-psm.json").toURI());
-        final JsonNode node = (JsonNode)JsonUtils.fromJson(serialized, JsonNode.class);
-        Set<ValidationMessage> validationMessages = schema.validate(node);
-        assertEquals(String.format("Json validation errors: %s", validationMessages), 0, validationMessages.size());
-    }
+    // Load json schema from resource
+    JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4);
+    final JsonSchema schema =
+        factory.getSchema(getClass().getClassLoader().getResource("schemas/schema-psm.json").toURI());
+    final JsonNode node = (JsonNode) JsonUtils.fromJson(serialized, JsonNode.class);
+    Set<ValidationMessage> validationMessages = schema.validate(node);
+    assertEquals(String.format("Json validation errors: %s", validationMessages), 0, validationMessages.size());
+  }
 
 }

--- a/jpo-ode-core/src/test/resources/json/sample-psm.json
+++ b/jpo-ode-core/src/test/resources/json/sample-psm.json
@@ -1,0 +1,49 @@
+{
+  "metadata": {
+    "logFileName": "",
+    "maxDurationTime": 0,
+    "odePacketID": "",
+    "odeReceivedAt": "2023-09-21T15:30:14.926500Z",
+    "odeTimStartDateTime": "",
+    "originIp": "192.168.16.1",
+    "payloadType": "us.dot.its.jpo.ode.model.OdePsmPayload",
+    "psmSource": "RSU",
+    "receivedMessageDetails": {
+      "rxSource": "NA"
+    },
+    "recordGeneratedAt": "",
+    "recordGeneratedBy": "UNKNOWN",
+    "recordType": "psmTx",
+    "sanitized": false,
+    "schemaVersion": 8,
+    "securityResultCode": "success",
+    "serialId": {
+      "bundleId": 0,
+      "bundleSize": 1,
+      "recordId": 0,
+      "serialNumber": 0,
+      "streamId": "06cc1c17-e331-4806-a8ee-456b98c6517b"
+    },
+    "asn1": "011d0000201a0000021bd86891de75f84da101c13f042e2214141fff00022c2000270000000163b2cc7986010000"
+  },
+  "payload": {
+    "data": {
+      "accuracy": {
+        "orientation": 44.9951935489,
+        "semiMajor": 1.0,
+        "semiMinor": 1.0
+      },
+      "basicType": "aPEDESTRIAN",
+      "heading": 8898,
+      "id": "24779D7E",
+      "msgCnt": 26,
+      "position": {
+        "latitude": 40.2397377,
+        "longitude": -74.2761437
+      },
+      "secMark": 3564,
+      "speed": 0
+    },
+    "dataType": "us.dot.its.jpo.ode.plugin.j2735.J2735PSM"
+  }
+} 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Updates the "recordGeneratedBy" field in the PSM schema to be the same as the BSM schema to allow String values specified in [OdeLogMetadata](https://github.com/CDOT-CV/jpo-ode/blob/dev/jpo-ode-core/src/main/java/us/dot/its/jpo/ode/model/OdeLogMetadata.java).

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Allow PSM messages to pass schema validation

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checking PSM schema validation failed with the old schema and succeeds with this schema (used the sample message in the [udpsender_psm.py](https://github.com/CDOT-CV/jpo-ode/blob/dev/scripts/tests/udpsender_psm.py) script

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ x ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
