### PR TITLE
Updated 2025 Q1 Release Notes to Reflect Partial J2735 2024 Compatibility

### DIFF
--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -67,9 +67,10 @@ Enhancements in this release:
 - [CDOT PR 152](https://github.com/CDOT-CV/jpo-ode/pull/152): TIM and Map Schema Fixes
 - [CDOT PR 153](https://github.com/CDOT-CV/jpo-ode/pull/153): Fix: producer failures
 - [CDOT PR 154](https://github.com/CDOT-CV/jpo-ode/pull/154): Fix: Use odeKafkaProperties env vars to drive producer retries
+- [CDOT PR 158](https://github.com/CDOT-CV/jpo-ode/pull/158): Release/PSM schema fix
+- [CDOT PR 160](https://github.com/CDOT-CV/jpo-ode/pull/160): Support Renamed Fields in J2735 2024 BSM Structures
 - [USDOT PR 559](https://github.com/usdot-jpo-ode/jpo-ode/pull/559): Update GitHub Actions Third-Party Action Versions
 - [USDOT PR 561](https://github.com/usdot-jpo-ode/jpo-ode/pull/561): Bump ch.qos.logback:logback-core from 1.4.14 to 1.5.13 in /jpo-ode-plugins
-- [CDOT PR 158](https://github.com/CDOT-CV/jpo-ode/pull/158): Release/PSM schema fix
 
 Breaking changes:
 - The major version was incremented to reflect breaking changes related to TIM XER encoding introduced in the 2024 revision of J2735.

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -13,8 +13,14 @@ Key highlights include:
 - Updates to TIM schemas and JSON annotations for more J2735-accurate ODE processing
 
 Significant strides have been made in optimizing configurations through enhancements like the extraction of Kafka properties,
-environment variables, and Kafka topics into more streamlined Spring Configuration properties. Additionally, schema
-updates have been made to increment the version for output messages and ensure compatibility with J2735 2024.
+environment variables, and Kafka topics into more streamlined Spring Configuration properties.
+
+Schema updates have been implemented to increment the version of output messages and provide partial compatibility with 
+J2735 2024. However, some limitations remain. Due to a bug in the ASN.1 Compiler, the VehicleEventFlags bitstring has 
+been reverted to its 2020 version, excluding the eventJackKnife bit introduced in the 2024 revision. As a result, this 
+bit will not appear in output BSMs until the issue is resolved. Additionally, certain fields added to BSM-related 
+structures in J2735 2024 are not yet supported in the ODE. These fields will be incorporated in a future release.
+
 Developer-focused changes include revisions to the README, Makefile, and devcontainer to support smoother onboarding and
 ease of use. Other vital updates encompass new entries in the submodule compatibility guide, version upgrades, and
 bug fixes related to Kafka configurations and message handling.
@@ -66,12 +72,13 @@ Enhancements in this release:
 - [CDOT PR 158](https://github.com/CDOT-CV/jpo-ode/pull/158): Release/PSM schema fix
 
 Breaking changes:
-- The major version was incremented due to breaking changes in the 2024 revision of J2735.
+- The major version was incremented to reflect breaking changes related to TIM XER encoding introduced in the 2024 revision of J2735.
 
 Known Issues:
-- No known issues at this time.
+- **VehicleEventFlags Bitstring Bug**: A bug in the ASN.1 Compiler has necessitated reverting the VehicleEventFlags bitstring to its 2020 version, which excludes the eventJackKnife bit added in the 2024 revision. As a result, this bit will not appear in output BSMs until the bug is fixed.
+- **Unsupported BSM Fields**: New fields introduced in BSM-related structures by the 2024 revision of J2735 are currently not supported in the ODE. These fields will be implemented in a future release.
 
-Version 3.0.0, released September 2024
+- Version 3.0.0, released September 2024
 ----------------------------------------
 ### **Summary**
 The updates for the jpo-ode 3.0.0 release include several key improvements and cleanups. Outdated 'deposit over WebSocket to SDX' code was removed and the ppm_tim service was eliminated from Docker compose files. Additionally, the jpo-s3-deposit submodule was replaced with the jpo-utils submodule. Error handling was enhanced, particularly in interpreting "SNMP Error Code 10" from RSUs and stack traces for bad encoded data from ACM are now printed only when debug logging is enabled. Documentation updates provide more granular project references and mapfile references in ppm*.properties files were updated. Build and deployment improvements include resolving a UID conflict for container builds and adding Maven JAR publishing to GitHub Maven Central via GitHub Actions. Lastly, a Docker startup script was introduced for log offloading via SSH/SCP and source ASN1 bytes payload support was added for IMP depositors.

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -78,7 +78,7 @@ Known Issues:
 - **VehicleEventFlags Bitstring Bug**: A bug in the ASN.1 Compiler has necessitated reverting the VehicleEventFlags bitstring to its 2020 version, which excludes the eventJackKnife bit added in the 2024 revision. As a result, this bit will not appear in output BSMs until the bug is fixed.
 - **Unsupported BSM Fields**: New fields introduced in BSM-related structures by the 2024 revision of J2735 are currently not supported in the ODE. These fields will be implemented in a future release.
 
-- Version 3.0.0, released September 2024
+Version 3.0.0, released September 2024
 ----------------------------------------
 ### **Summary**
 The updates for the jpo-ode 3.0.0 release include several key improvements and cleanups. Outdated 'deposit over WebSocket to SDX' code was removed and the ppm_tim service was eliminated from Docker compose files. Additionally, the jpo-s3-deposit submodule was replaced with the jpo-utils submodule. Error handling was enhanced, particularly in interpreting "SNMP Error Code 10" from RSUs and stack traces for bad encoded data from ACM are now printed only when debug logging is enabled. Documentation updates provide more granular project references and mapfile references in ppm*.properties files were updated. Build and deployment improvements include resolving a UID conflict for container builds and adding Maven JAR publishing to GitHub Maven Central via GitHub Actions. Lastly, a Docker startup script was introduced for log offloading via SSH/SCP and source ASN1 bytes payload support was added for IMP depositors.

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -16,7 +16,7 @@ Significant strides have been made in optimizing configurations through enhancem
 environment variables, and Kafka topics into more streamlined Spring Configuration properties.
 
 Schema updates have been implemented to increment the version of output messages and provide partial compatibility with 
-J2735 2024. However, some limitations remain. Due to a bug in the ASN.1 Compiler, the VehicleEventFlags bitstring has 
+J2735 2024. However, some limitations remain. Due to [a bug in the ASN.1 Compiler](https://github.com/usdot-fhwa-stol/usdot-asn1c/issues/2), the VehicleEventFlags bitstring has 
 been reverted to its 2020 version, excluding the eventJackKnife bit introduced in the 2024 revision. As a result, this 
 bit will not appear in output BSMs until the issue is resolved. Additional fields added to BSM-related 
 structures in J2735 2024 are not yet supported in the ODE. These fields will be incorporated in a future release.

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -15,13 +15,17 @@ Key highlights include:
 Significant strides have been made in optimizing configurations through enhancements like the extraction of Kafka properties,
 environment variables, and Kafka topics into more streamlined Spring Configuration properties.
 
-Schema updates have been implemented to increment the version of output messages and provide partial compatibility with 
-J2735 2024. However, some limitations remain. Due to [a bug in the ASN.1 Compiler](https://github.com/usdot-fhwa-stol/usdot-asn1c/issues/2), the VehicleEventFlags bitstring has 
-been reverted to its 2020 version, excluding the eventJackKnife bit introduced in the 2024 revision. As a result, this 
-bit will not appear in output BSMs until the issue is resolved. Additionally, new fields added to BSM-related structures in 
-J2735 2024 are not yet supported in the ODE. These fields—such as fhwaVehicleClass, trailers, and schoolBus for 
-SupplementalVehicleExtensions, as well as trailerPresent, pivotPoint, axles, and leanAngle for VehicleData—will be
-incorporated in a future release.
+Schema updates have been applied to increment the version of output messages and provide partial compatibility with J2735 2024. 
+However, several limitations remain. 
+- Due to [a bug in the ASN.1 Compiler](https://github.com/usdot-fhwa-stol/usdot-asn1c/issues/2), the VehicleEventFlags bitstring has been reverted to 
+  its 2020 version. This excludes the eventJackKnife bit introduced in the 2024 revision, which will not appear in output BSMs 
+  until the issue is resolved.
+- Additionally, fields newly added in J2735 2024 to BSM-related structures are not yet supported in the ODE. These include 
+  fhwaVehicleClass, trailers, and schoolBus under SupplementalVehicleExtensions, as well as trailerPresent, pivotPoint, axles, 
+  and leanAngle under VehicleData.
+- Similarly, new fields introduced for MAPs, SPATs, and TIMs, such as roadAuthorityId and contentNew, are not currently supported 
+  in the ODE.
+- These limitations will be addressed in future updates.
 
 Developer-focused changes include revisions to the README, Makefile, and devcontainer to support smoother onboarding and
 ease of use. Other vital updates encompass new entries in the submodule compatibility guide, version upgrades, and

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -18,8 +18,10 @@ environment variables, and Kafka topics into more streamlined Spring Configurati
 Schema updates have been implemented to increment the version of output messages and provide partial compatibility with 
 J2735 2024. However, some limitations remain. Due to [a bug in the ASN.1 Compiler](https://github.com/usdot-fhwa-stol/usdot-asn1c/issues/2), the VehicleEventFlags bitstring has 
 been reverted to its 2020 version, excluding the eventJackKnife bit introduced in the 2024 revision. As a result, this 
-bit will not appear in output BSMs until the issue is resolved. Additional fields added to BSM-related 
-structures in J2735 2024 are not yet supported in the ODE. These fields will be incorporated in a future release.
+bit will not appear in output BSMs until the issue is resolved. Additionally, new fields added to BSM-related structures in 
+J2735 2024 are not yet supported in the ODE. These fields—such as fhwaVehicleClass, trailers, and schoolBus for 
+SupplementalVehicleExtensions, as well as trailerPresent, pivotPoint, axles, and leanAngle for VehicleData—will be
+incorporated in a future release.
 
 Developer-focused changes include revisions to the README, Makefile, and devcontainer to support smoother onboarding and
 ease of use. Other vital updates encompass new entries in the submodule compatibility guide, version upgrades, and

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -18,7 +18,7 @@ environment variables, and Kafka topics into more streamlined Spring Configurati
 Schema updates have been implemented to increment the version of output messages and provide partial compatibility with 
 J2735 2024. However, some limitations remain. Due to a bug in the ASN.1 Compiler, the VehicleEventFlags bitstring has 
 been reverted to its 2020 version, excluding the eventJackKnife bit introduced in the 2024 revision. As a result, this 
-bit will not appear in output BSMs until the issue is resolved. Additionally, certain fields added to BSM-related 
+bit will not appear in output BSMs until the issue is resolved. Additional fields added to BSM-related 
 structures in J2735 2024 are not yet supported in the ODE. These fields will be incorporated in a future release.
 
 Developer-focused changes include revisions to the README, Makefile, and devcontainer to support smoother onboarding and


### PR DESCRIPTION
# PR Details
## Description
This pull request updates the 2025 Q1 release notes to reflect changes made for partial compatibility with J2735 2024. Schema updates have been implemented to increment the version of output messages. However, due to a bug in the ASN.1 Compiler, the VehicleEventFlags bitstring has been reverted to its 2020 version, meaning the new eventJackKnife bit from the 2024 revision will not appear in output BSMs until the issue is resolved. Additionally, some new fields introduced in J2735 2024 for BSM-related structures are not yet supported in the ODE but will be included in a future release.

## Related Issue
No related GitHub issue.

## Motivation and Context
J2735 2024 includes updates that require changes to message structures, and we’ve made progress in supporting these updates. While there are some known limitations, like the missing eventJackKnife bit and unsupported fields, this update provides clarity about the current state of compatibility. The goal is to keep users informed about what’s available now and what will be included in future releases.

## How Has This Been Tested?
Documentation change, no testing necessary.

## Types of changes
- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)
- [x] Documentation

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
