### PR TITLE
fix: force BigDecimal serialization to NUMBER format

### DIFF
--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -75,6 +75,7 @@ Enhancements in this release:
 - [CDOT PR 154](https://github.com/CDOT-CV/jpo-ode/pull/154): Fix: Use odeKafkaProperties env vars to drive producer retries
 - [CDOT PR 158](https://github.com/CDOT-CV/jpo-ode/pull/158): Release/PSM schema fix
 - [CDOT PR 160](https://github.com/CDOT-CV/jpo-ode/pull/160): Support Renamed Fields in J2735 2024 BSM Structures
+- [CDOT PR 165](https://github.com/CDOT-CV/jpo-ode/pull/165): fix: force BigDecimal serialization to NUMBER format
 - [USDOT PR 559](https://github.com/usdot-jpo-ode/jpo-ode/pull/559): Update GitHub Actions Third-Party Action Versions
 - [USDOT PR 561](https://github.com/usdot-jpo-ode/jpo-ode/pull/561): Bump ch.qos.logback:logback-core from 1.4.14 to 1.5.13 in /jpo-ode-plugins
 

--- a/jpo-ode-common/src/main/java/us/dot/its/jpo/ode/util/JsonUtils.java
+++ b/jpo-ode-common/src/main/java/us/dot/its/jpo/ode/util/JsonUtils.java
@@ -16,6 +16,7 @@
 package us.dot.its.jpo.ode.util;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -27,15 +28,13 @@ import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.type.LogicalType;
-import lombok.extern.slf4j.Slf4j;
-import org.json.JSONObject;
-
-
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map.Entry;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
 
 @Slf4j
 public class JsonUtils {
@@ -65,6 +64,10 @@ public class JsonUtils {
       mapper_noNulls = new ObjectMapper();
       mapper_noNulls.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
       mapper_noNulls.setSerializationInclusion(Include.NON_NULL);
+
+      // Ensure BigDecimals are serialized constistently as numbers not strings
+      mapper.configOverride(BigDecimal.class).setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.NUMBER));
+      mapper_noNulls.configOverride(BigDecimal.class).setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.NUMBER));
    }
 
    public static String toJson(Object o, boolean verbose) {

--- a/jpo-ode-common/src/main/java/us/dot/its/jpo/ode/util/JsonUtils.java
+++ b/jpo-ode-common/src/main/java/us/dot/its/jpo/ode/util/JsonUtils.java
@@ -65,7 +65,7 @@ public class JsonUtils {
       mapper_noNulls.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
       mapper_noNulls.setSerializationInclusion(Include.NON_NULL);
 
-      // Ensure BigDecimals are serialized constistently as numbers not strings
+      // Ensure BigDecimals are serialized consistently as numbers not strings
       mapper.configOverride(BigDecimal.class).setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.NUMBER));
       mapper_noNulls.configOverride(BigDecimal.class).setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.NUMBER));
    }

--- a/jpo-ode-core/src/main/resources/schemas/schema-map.json
+++ b/jpo-ode-core/src/main/resources/schemas/schema-map.json
@@ -1021,7 +1021,7 @@
                                                     "properties": {
                                                         "elevation": {
                                                             "type": [
-                                                                "string"
+                                                                "number"
                                                             ]
                                                         },
                                                         "latitude": {

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/config/SerializationConfig.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/config/SerializationConfig.java
@@ -1,6 +1,7 @@
 package us.dot.its.jpo.ode.config;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -9,6 +10,7 @@ import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.type.LogicalType;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper.Builder;
+import java.math.BigDecimal;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -33,6 +35,8 @@ public class SerializationConfig {
     mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
     mapper.coercionConfigFor(LogicalType.Enum)
         .setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsNull);
+    // Ensure BigDecimals are serialized consistently as numbers not strings
+    mapper.configOverride(BigDecimal.class).setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.NUMBER));
     return mapper;
   }
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Configure the ObjectMappers used by the ToJsonConverter and KafkaTemplates to serialize BigDecimal fields as numbers instead of (occasionally) Strings.

Before:
```json
{
...
"accelSet": {
          "accelLat": 2001,
          "accelLong": -0.33,
          "accelVert": -127,
          "accelYaw": -0.23
        },
        "accuracy": {
          "semiMajor": "2.00",
          "semiMinor": "2.00",
          "orientation": "0E-10"
        }
       }
...
}
```

After:
```json
{
...
"accelSet": {
          "accelLat": 2001,
          "accelLong": -0.33,
          "accelVert": -127,
          "accelYaw": -0.23
        },
        "accuracy": {
          "semiMajor": 2.00,
          "semiMinor": 2.00,
          "orientation": 0.0000000000
        }
       }
...
}
```

Also, update the map json schema to align with the ASN1 spec by updating the data type from string to number

> The DE_Elevation data element represents the geographic position above or below the reference ellipsoid (typically WGS-84). The number has a resolution of 1 decimeter and represents an asymmetric range of positive and negative values. Any elevation higher than +6143.9 m is represented as +61439. Any elevation lower than -409.5 m is represented as -4095. If the sending device does not know its elevation, it shall encode the Elevation data element with -4096.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
The ODE was set up locally using docker compose. Test scripts were used to send messages to the UDP endpoints, and the output for each message type was validated against its corresponding schema.
- Messages were retrieved from `topic.Ode(MessageType)Json` topics using bitnami consumer script inside running container
- Schemas were retrieved from links in https://github.com/CDOT-CV/jpo-ode/blob/mcook42/hotfix/set-big-decimal-serialization-2/docs/schemas/README.md
- https://www.jsonschemavalidator.net/ was used for validation

Additionally, this has been deployed to CDOT GCP dev.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
