### PR TITLE
Fix: update InetPacketFunctionalTest to prevent flaky test failures

### DIFF
--- a/jpo-ode-common/src/main/java/us/dot/its/jpo/ode/inet/InetPoint.java
+++ b/jpo-ode-common/src/main/java/us/dot/its/jpo/ode/inet/InetPoint.java
@@ -1,18 +1,19 @@
-/*******************************************************************************
+/*=============================================================================
  * Copyright 2018 572682
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy
  * of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
  * License for the specific language governing permissions and limitations under
  * the License.
  ******************************************************************************/
+
 package us.dot.its.jpo.ode.inet;
 
 import java.net.InetAddress;
@@ -20,51 +21,64 @@ import java.net.UnknownHostException;
 import lombok.extern.slf4j.Slf4j;
 import us.dot.its.jpo.ode.util.CodecUtils;
 
+/**
+ * Represents a network endpoint with an IP address, port, and an optional forward flag.
+ * This class provides utilities for handling and representing IP-based network endpoints.
+ */
 @Slf4j
 public class InetPoint {
 
-	public final byte[] address;
-	public final int port;
-	public final boolean forward;
-	
-	public InetPoint(String host, int port, boolean forward) throws UnknownHostException {
-		this(InetAddress.getByName(host).getAddress(), port, forward);
-	}
-	
-	public InetPoint(byte[] address, int port) {
-		this(address, port, false);
-	}
-	
-	public InetPoint(byte[] address, int port, boolean forward ) {
-		if (address == null) {
-		  throw new IllegalArgumentException("IP Address is required");
-		}
-		this.address = address;
-		this.port = port;
-		this.forward = forward;
-	}
-	
-	public InetAddress getInetAddress() throws UnknownHostException {
-		return InetAddress.getByAddress(address);
-	}
-	
-	public boolean isIPv6Address() {
-		return address.length == 16;
-	}
-	
-	@Override
-	public String toString() {
-		String host = "?";
-		try {
-			host = InetAddress.getByAddress(address).getHostAddress();
-		} catch (UnknownHostException e) {
-		  log.error("Error", e);
-		}
-		return String.format("%s { port = %d (0x%x); address = %s (%s, %s); forward = %s }",
-				getClass().getSimpleName(),
-				port, port,
-				CodecUtils.toHex(address), address.length == 4 ? "IPv4" : "IPv6", host,
-				forward ? "true" : "false"
-				);
-	}
+  public final byte[] address;
+  public final int port;
+  public final boolean forward;
+
+  public InetPoint(String host, int port, boolean forward) throws UnknownHostException {
+    this(InetAddress.getByName(host).getAddress(), port, forward);
+  }
+
+  public InetPoint(byte[] address, int port) {
+    this(address, port, false);
+  }
+
+  /**
+   * Constructs an InetPoint object.
+   *
+   * @param address The byte array representing the IP address of the endpoint. Must not be null.
+   * @param port    The port number of the endpoint.
+   * @param forward A boolean flag indicating whether the endpoint is configured for forwarding.
+   *
+   * @throws IllegalArgumentException if the address parameter is null.
+   */
+  public InetPoint(byte[] address, int port, boolean forward) {
+    if (address == null) {
+      throw new IllegalArgumentException("IP Address is required");
+    }
+    this.address = address;
+    this.port = port;
+    this.forward = forward;
+  }
+
+  public InetAddress getInetAddress() throws UnknownHostException {
+    return InetAddress.getByAddress(address);
+  }
+
+  public boolean isIPv6Address() {
+    return address.length == 16;
+  }
+
+  @Override
+  public String toString() {
+    String host = "?";
+    try {
+      host = InetAddress.getByAddress(address).getHostAddress();
+    } catch (UnknownHostException e) {
+      log.error("Error", e);
+    }
+    return String.format("%s { port = %d (0x%x); address = %s (%s, %s); forward = %s }",
+        getClass().getSimpleName(),
+        port, port,
+        CodecUtils.toHex(address), address.length == 4 ? "IPv4" : "IPv6", host,
+        forward ? "true" : "false"
+    );
+  }
 }

--- a/jpo-ode-common/src/main/java/us/dot/its/jpo/ode/inet/InetPoint.java
+++ b/jpo-ode-common/src/main/java/us/dot/its/jpo/ode/inet/InetPoint.java
@@ -17,14 +17,11 @@ package us.dot.its.jpo.ode.inet;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import lombok.extern.slf4j.Slf4j;
 import us.dot.its.jpo.ode.util.CodecUtils;
 
+@Slf4j
 public class InetPoint {
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
 	public final byte[] address;
 	public final int port;
@@ -61,7 +58,7 @@ public class InetPoint {
 		try {
 			host = InetAddress.getByAddress(address).getHostAddress();
 		} catch (UnknownHostException e) {
-		  logger.error("Error", e);
+		  log.error("Error", e);
 		}
 		return String.format("%s { port = %d (0x%x); address = %s (%s, %s); forward = %s }",
 				getClass().getSimpleName(),

--- a/jpo-ode-common/src/test/java/us/dot/its/jpo/ode/inet/InetPacketFunctionalTest.java
+++ b/jpo-ode-common/src/test/java/us/dot/its/jpo/ode/inet/InetPacketFunctionalTest.java
@@ -16,11 +16,11 @@
 
 package us.dot.its.jpo.ode.inet;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.DatagramPacket;
 import java.net.InetAddress;
@@ -30,12 +30,12 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import us.dot.its.jpo.ode.util.CodecUtils;
 
-public class InetPacketFunctionalTest {
+class InetPacketFunctionalTest {
 
   private static boolean isVerbose = false;
 
   @Test
-  public void testConstrcutor() throws UnknownHostException {
+  void testConstrcutor() throws UnknownHostException {
     InetPacket pkt = new InetPacket("bah.com", 1111, null);
 
     assertNull(pkt.getPayload());
@@ -43,7 +43,7 @@ public class InetPacketFunctionalTest {
 
   @Test
   @Disabled
-  public void test() throws UnknownHostException {
+  void test() throws UnknownHostException {
     test("127.0.0.1", 12, "01234567890".getBytes());
     test("::1", 47561, "0123456789001234567890".getBytes());
     test("1080:0:0:0:8:800:200C:417A", 345, "".getBytes());
@@ -56,7 +56,7 @@ public class InetPacketFunctionalTest {
     test("fdf8:f53b:82e4::53", 11111, new byte[] {(byte) 0xca, (byte) 0xfe, (byte) 0xba, (byte) 0xbe});
   }
 
-  public void test(String address, int port, byte[] payload) throws UnknownHostException {
+  void test(String address, int port, byte[] payload) throws UnknownHostException {
     if (payload == null) {
       return;
     }
@@ -68,7 +68,7 @@ public class InetPacketFunctionalTest {
     test(address, port, payload, pbOut);
   }
 
-  public void test(String address, int port, byte[] payload, InetPacket pbOut) throws UnknownHostException {
+  void test(String address, int port, byte[] payload, InetPacket pbOut) throws UnknownHostException {
     InetPacket pbIn = new InetPacket(pbOut.getBundle());
     if (isVerbose) {
       print("From params", pbOut);

--- a/jpo-ode-common/src/test/java/us/dot/its/jpo/ode/inet/InetPacketFunctionalTest.java
+++ b/jpo-ode-common/src/test/java/us/dot/its/jpo/ode/inet/InetPacketFunctionalTest.java
@@ -1,18 +1,19 @@
-/*******************************************************************************
+/*=============================================================================
  * Copyright 2018 572682
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy
  * of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
  * License for the specific language governing permissions and limitations under
  * the License.
  ******************************************************************************/
+
 package us.dot.its.jpo.ode.inet;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -22,86 +23,86 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.DatagramPacket;
-import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
-import mockit.Capturing;
 import us.dot.its.jpo.ode.util.CodecUtils;
 
 public class InetPacketFunctionalTest {
-   
-	private static boolean isVerbose = false;
-	
-  @Test
-	public void testConstrcutor() throws UnknownHostException {
-	   InetPacket pkt = new InetPacket("bah.com", 1111, null);
-	   
-	   assertNull(pkt.getPayload());
-	}
-	
-	@Test @Disabled
-	public void test() throws UnknownHostException {
-		test("127.0.0.1", 12, "01234567890".getBytes());
-		test("::1", 47561, "0123456789001234567890".getBytes());
-		test("1080:0:0:0:8:800:200C:417A", 345, "".getBytes());
-		test("1080:0:0:0:8:800:200C:417A", 345, null);
-		test("1.0.0", 47561, "".getBytes());
-		test("::FFFF:129.144.52.38", 4756, "0".getBytes());
-		test("1080::8:800:200C:417A", 4756, new byte[] { (byte)0, (byte)1 });
-		test("2001:0:9d38:90d7:3ce3:339d:f5c3:c42b", 11111, new byte[] { (byte)0xde, (byte)0xad, (byte)0xbe, (byte)0xef });
-		test(null, 22222, new byte[] { (byte)0xde, (byte)0xad, (byte)0xbe, (byte)0xef });
-		test("fdf8:f53b:82e4::53", 11111, new byte[] { (byte)0xca, (byte)0xfe, (byte)0xba, (byte)0xbe });
-	}
-	
-	public void test(String address, int port, byte[] payload) throws UnknownHostException {
-		if ( payload == null )
-			return;
-		if ( isVerbose ) 
-			System.out.println("---------- Test ----------");		
-		DatagramPacket packet = new DatagramPacket(payload, payload.length, InetAddress.getByName(address), port);
-		InetPacket pbOut = new InetPacket(packet);
-		test(address, port, payload, pbOut);
-	}
 
-	public void test(String address, int port, byte[] payload, InetPacket pbOut) throws UnknownHostException {
-		InetPacket pbIn = new InetPacket(pbOut.getBundle());
-		if ( isVerbose ) {
-			print("From params", pbOut);
-			print("From bundle", pbIn);
-		}
-		InetPoint pointIn = pbIn.getPoint();
-		assertNotNull(pointIn);
-		InetPoint pointOut = pbOut.getPoint();
-		assertEquals(pointOut.port, pointIn.port);
-		assertArrayEquals(pointOut.address, pointIn.address);
-		byte[] pbOutPayload = pbOut.getPayload();
-		byte[] pyInPayload = pbIn.getPayload();
-		if ( pbOutPayload != null && pbOutPayload != null )
-			assertTrue(Arrays.equals(pbOutPayload, pyInPayload));
-		else if (pbOutPayload != null || pbOutPayload != null)
-			assertTrue(false);
-		assertTrue(Arrays.equals(pbOut.getBundle(), pbIn.getBundle()));		
-	}
-	
-	void print(String header, InetPacket pb) throws UnknownHostException {
-		assertNotNull(pb);
-		InetPoint point = pb.getPoint();
-		if( point != null ) {
-			System.out.printf("%s: port:  %d (0x%x)\n", header, point.port, point.port );
-			System.out.printf("%s: address size: %d value: %s ip: %s\n", header, point.address.length, 
-					CodecUtils.toHex(point.address), InetAddress.getByAddress(point.address).getHostAddress() );
-			System.out.printf("%s: forward:  %s\n", header, point.forward ? "true" : "false" );
-		} else {
-			System.out.printf("%s: Inet point is null\n", header);
-		}
-		byte[] p = pb.getPayload();
-		System.out.printf("%s payload: %s\n", header, p != null && p.length > 0 ? CodecUtils.toHex(p) : "<empty>");
-		System.out.printf("%s bundle: %s\n", header, pb.toHexString());
-	}
+  private static boolean isVerbose = false;
+
+  @Test
+  public void testConstrcutor() throws UnknownHostException {
+    InetPacket pkt = new InetPacket("bah.com", 1111, null);
+
+    assertNull(pkt.getPayload());
+  }
+
+  @Test
+  @Disabled
+  public void test() throws UnknownHostException {
+    test("127.0.0.1", 12, "01234567890".getBytes());
+    test("::1", 47561, "0123456789001234567890".getBytes());
+    test("1080:0:0:0:8:800:200C:417A", 345, "".getBytes());
+    test("1080:0:0:0:8:800:200C:417A", 345, null);
+    test("1.0.0", 47561, "".getBytes());
+    test("::FFFF:129.144.52.38", 4756, "0".getBytes());
+    test("1080::8:800:200C:417A", 4756, new byte[] {(byte) 0, (byte) 1});
+    test("2001:0:9d38:90d7:3ce3:339d:f5c3:c42b", 11111, new byte[] {(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef});
+    test(null, 22222, new byte[] {(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef});
+    test("fdf8:f53b:82e4::53", 11111, new byte[] {(byte) 0xca, (byte) 0xfe, (byte) 0xba, (byte) 0xbe});
+  }
+
+  public void test(String address, int port, byte[] payload) throws UnknownHostException {
+    if (payload == null) {
+      return;
+    }
+    if (isVerbose) {
+      System.out.println("---------- Test ----------");
+    }
+    DatagramPacket packet = new DatagramPacket(payload, payload.length, InetAddress.getByName(address), port);
+    InetPacket pbOut = new InetPacket(packet);
+    test(address, port, payload, pbOut);
+  }
+
+  public void test(String address, int port, byte[] payload, InetPacket pbOut) throws UnknownHostException {
+    InetPacket pbIn = new InetPacket(pbOut.getBundle());
+    if (isVerbose) {
+      print("From params", pbOut);
+      print("From bundle", pbIn);
+    }
+    InetPoint pointIn = pbIn.getPoint();
+    assertNotNull(pointIn);
+    InetPoint pointOut = pbOut.getPoint();
+    assertEquals(pointOut.port, pointIn.port);
+    assertArrayEquals(pointOut.address, pointIn.address);
+    byte[] pbOutPayload = pbOut.getPayload();
+    byte[] pyInPayload = pbIn.getPayload();
+    if (pbOutPayload != null && pbOutPayload != null) {
+      assertTrue(Arrays.equals(pbOutPayload, pyInPayload));
+    } else if (pbOutPayload != null || pbOutPayload != null) {
+      assertTrue(false);
+    }
+    assertTrue(Arrays.equals(pbOut.getBundle(), pbIn.getBundle()));
+  }
+
+  void print(String header, InetPacket pb) throws UnknownHostException {
+    assertNotNull(pb);
+    InetPoint point = pb.getPoint();
+    if (point != null) {
+      System.out.printf("%s: port:  %d (0x%x)\n", header, point.port, point.port);
+      System.out.printf("%s: address size: %d value: %s ip: %s\n", header, point.address.length,
+          CodecUtils.toHex(point.address), InetAddress.getByAddress(point.address).getHostAddress());
+      System.out.printf("%s: forward:  %s\n", header, point.forward ? "true" : "false");
+    } else {
+      System.out.printf("%s: Inet point is null\n", header);
+    }
+    byte[] p = pb.getPayload();
+    System.out.printf("%s payload: %s\n", header, p != null && p.length > 0 ? CodecUtils.toHex(p) : "<empty>");
+    System.out.printf("%s bundle: %s\n", header, pb.toHexString());
+  }
 
 }

--- a/jpo-ode-common/src/test/java/us/dot/its/jpo/ode/inet/InetPacketFunctionalTest.java
+++ b/jpo-ode-common/src/test/java/us/dot/its/jpo/ode/inet/InetPacketFunctionalTest.java
@@ -35,7 +35,7 @@ class InetPacketFunctionalTest {
   private static boolean isVerbose = false;
 
   @Test
-  void testConstrcutor() throws UnknownHostException {
+  void testConstructor() throws UnknownHostException {
     InetPacket pkt = new InetPacket("bah.com", 1111, null);
 
     assertNull(pkt.getPayload());


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
- Use `@Slf4j` annotation to construct logger in InetPoint to prevent flaky errors in tests
- Address Checkstyle violations in changed files (formatting, javadocs)
- Update InetPacketFunctionalTest to consistently use `junit.jupiter.api` 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This should address a flaky test failure we saw in https://github.com/usdot-jpo-ode/jpo-ode/actions/runs/12918350007/job/36079870160?pr=562

![image](https://github.com/user-attachments/assets/ae23fd45-58d1-4520-8653-f46c48c7bc74)


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/bugfix/Pull_request_template/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
