### PR TITLE
Update Quarterly Release and Hotfix Documentation

### DIFF
--- a/docs/release_process_hotfix.md
+++ b/docs/release_process_hotfix.md
@@ -34,6 +34,7 @@ After the hotfix branch is created and the code changes are merged, project refe
 3. Tag docker images with the version number of each app. (e.g. 1.0.0)
 4. Tag docker images with year, month, and day of hotfix. (e.g. 2024-04-01)
 5. Tag docker images with 'latest' tag for the most recent release.
+6. Tag docker images with `(year)-(quarter)` to indicate the quarter of the release. (e.g. 2024-Q2)
 
 #### Housekeeping
 1. Merge master branches into develop branches for each affected project & verify that CI/CD passes.

--- a/docs/release_process_quarterly.md
+++ b/docs/release_process_quarterly.md
@@ -517,7 +517,7 @@ None
 
 ### 3. Project Reference Updates & Release Creation
     - [ ] Merge `release/(year)-(quarter)` branch into `master` branch for the jpo-cvmanager project, and create a release with the version number of the release. (e.g. jpo-cvmanager-x.x.x)
-
+    - [ ] Merge master branch into develop branch & verify that CI/CD passes.
 
 ## jpo-s3-deposit
 ### Prerequisites


### PR DESCRIPTION
# PR Details
## Description
## Problem
- The jpo-cvmanager section was missing a step.
- The hotfix documentation did not specify that the quarter-specific image tag should be overwritten.

## Solution
- Added a step in the jpo-cvmanager section to merge the master branch back into develop.
- Updated the hotfix documentation to include a (year)-(quarter) tagging requirement.

## Related Issue
No related GitHub issue.

## Motivation and Context
Ensuring a smooth and consistent release process for the jpo-cvmanager project requires clear and complete documentation. The missing step for merging master back into develop could lead to inconsistencies in the codebase, while the lack of guidance on overwriting the quarter-specific image tag could cause versioning issues. These updates address these gaps, improving clarity and preventing potential deployment errors.

## How Has This Been Tested?
Documentation update, no testing necessary.

## Types of changes
- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)
- [x] Documentation

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/develop/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
