### PR TITLE
Fix: UDP Receiver thread management

### DIFF
--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/Asn1EncodedDataRouter.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/Asn1EncodedDataRouter.java
@@ -164,7 +164,7 @@ public class Asn1EncodedDataRouter {
 
       log.error("ASN.1 encoding failed with code {} and message {}.", code, message);
       throw new Asn1EncodedDataRouterException(
-          "ASN.1 encoding failed with code %s and message %s.".formatted(code, message));
+          "ASN.1 encoding failed for offset %d with code %s and message %s.".formatted(consumerRecord.offset(), code, message));
     }
     if (!payloadData.has(ADVISORY_SITUATION_DATA_STRING)) {
       processUnsignedMessage(request, metadata, payloadData);

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/Asn1EncodedDataRouter.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/services/asn1/Asn1EncodedDataRouter.java
@@ -147,9 +147,9 @@ public class Asn1EncodedDataRouter {
 
     if (!metadata.has(TimTransmogrifier.REQUEST_STRING)) {
       throw new Asn1EncodedDataRouterException(
-          String.format("Invalid or missing '%s' object in the encoder response. Unable to process record with key '%s'",
+          String.format("Invalid or missing '%s' object in the encoder response. Unable to process record with offset '%s'",
               TimTransmogrifier.REQUEST_STRING,
-              consumerRecord.key())
+              consumerRecord.offset())
       );
     }
 

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/controller/UdpServicesController.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/udp/controller/UdpServicesController.java
@@ -1,9 +1,14 @@
 package us.dot.its.jpo.ode.udp.controller;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.scheduling.concurrent.DefaultManagedTaskExecutor;
 import org.springframework.stereotype.Controller;
 import us.dot.its.jpo.ode.kafka.topics.RawEncodedJsonTopics;
 import us.dot.its.jpo.ode.udp.bsm.BsmReceiver;
@@ -22,6 +27,9 @@ import us.dot.its.jpo.ode.udp.tim.TimReceiver;
 @Slf4j
 public class UdpServicesController {
 
+  private final List<ExecutorService> executors = new ArrayList<>();
+  private final List<AutoCloseable> receivers = new ArrayList<>();
+
   /**
    * Constructs a UdpServicesController to manage UDP receiver services for different message
    * types.
@@ -32,30 +40,83 @@ public class UdpServicesController {
    */
   @Autowired
   public UdpServicesController(UDPReceiverProperties udpProps,
-      RawEncodedJsonTopics rawEncodedJsonTopics,
-      KafkaTemplate<String, String> kafkaTemplate) {
-    super();
+                               RawEncodedJsonTopics rawEncodedJsonTopics,
+                               KafkaTemplate<String, String> kafkaTemplate) {
 
-    var serviceManager = new DefaultManagedTaskExecutor();
     log.debug("Starting UDP receiver services...");
 
-    serviceManager.submit(
-        new BsmReceiver(udpProps.getBsm(), kafkaTemplate, rawEncodedJsonTopics.getBsm()));
-    serviceManager.submit(
-        new TimReceiver(udpProps.getTim(), kafkaTemplate, rawEncodedJsonTopics.getTim()));
-    serviceManager.submit(
-        new SsmReceiver(udpProps.getSsm(), kafkaTemplate, rawEncodedJsonTopics.getSsm()));
-    serviceManager.submit(
-        new SrmReceiver(udpProps.getSrm(), kafkaTemplate, rawEncodedJsonTopics.getSrm()));
-    serviceManager.submit(
-        new SpatReceiver(udpProps.getSpat(), kafkaTemplate, rawEncodedJsonTopics.getSpat()));
-    serviceManager.submit(
-        new MapReceiver(udpProps.getMap(), kafkaTemplate, rawEncodedJsonTopics.getMap()));
-    serviceManager.submit(
-        new PsmReceiver(udpProps.getPsm(), kafkaTemplate, rawEncodedJsonTopics.getPsm()));
-    serviceManager.submit(
-        new GenericReceiver(udpProps.getGeneric(), kafkaTemplate, rawEncodedJsonTopics));
+    startReceiver(new BsmReceiver(udpProps.getBsm(), kafkaTemplate, rawEncodedJsonTopics.getBsm()));
+    startReceiver(new TimReceiver(udpProps.getTim(), kafkaTemplate, rawEncodedJsonTopics.getTim()));
+    startReceiver(new SsmReceiver(udpProps.getSsm(), kafkaTemplate, rawEncodedJsonTopics.getSsm()));
+    startReceiver(new SrmReceiver(udpProps.getSrm(), kafkaTemplate, rawEncodedJsonTopics.getSrm()));
+    startReceiver(new SpatReceiver(udpProps.getSpat(), kafkaTemplate, rawEncodedJsonTopics.getSpat()));
+    startReceiver(new MapReceiver(udpProps.getMap(), kafkaTemplate, rawEncodedJsonTopics.getMap()));
+    startReceiver(new PsmReceiver(udpProps.getPsm(), kafkaTemplate, rawEncodedJsonTopics.getPsm()));
+    startReceiver(new GenericReceiver(udpProps.getGeneric(), kafkaTemplate, rawEncodedJsonTopics));
 
     log.debug("UDP receiver services started.");
+  }
+
+  /**
+   * Starts a receiver in its own executor service and manages its lifecycle.
+   *
+   * @param receiver The receiver to start
+   */
+  private void startReceiver(Runnable receiver) {
+    ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
+      Thread thread = new Thread(r);
+      thread.setDaemon(true); // Makes thread exit when main application exits
+      return thread;
+    });
+
+    executors.add(executor);
+    if (receiver instanceof AutoCloseable closeable) {
+      receivers.add(closeable);
+    }
+
+    executor.submit(() -> {
+      try {
+        while (!Thread.currentThread().isInterrupted()) {
+          receiver.run();
+        }
+      } catch (Exception e) {
+        log.error("Error in receiver {}: {}", receiver.getClass().getSimpleName(), e.getMessage(), e);
+      }
+    });
+  }
+
+  /**
+   * Gracefully shuts down all executor services and closes all receivers.
+   */
+  @PreDestroy
+  public void shutdown() {
+    log.info("Shutting down UDP services...");
+
+    // First, shutdown all executors
+    executors.forEach(executor -> {
+      try {
+        executor.shutdown();
+        if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+          executor.shutdownNow();
+          if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+            log.error("Executor did not terminate");
+          }
+        }
+      } catch (InterruptedException e) {
+        executor.shutdownNow();
+        Thread.currentThread().interrupt();
+      }
+    });
+
+    // Then, close all receivers
+    receivers.forEach(receiver -> {
+      try {
+        receiver.close();
+      } catch (Exception e) {
+        log.error("Error closing receiver: {}", e.getMessage(), e);
+      }
+    });
+
+    log.info("UDP services shutdown completed.");
   }
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
- Improve thread management in the UdpServicesController.
- Add offsets to improve logging of Asn1EncodedDataRouter consumption from the AEM. This helps us identify the message on the topic so that we can inspect it and identify any issues.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
A combination of changes in the Spring Kafka migration PRs caused the UDP Receiver thread management to fail. The threads were created, but the BSMReceiver thread was blocking the execution of the other receivers. We need the receivers to run on separately managed threads so that we can consume UDP data independently.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have locally deployed the ODE and stepped through with a debugger to confirm data is consumed from the UDP endpoints correctly. I ran the udp_sender scripts for each message type.

I have also deployed a development build docker image to the GCP dev cluster to confirm that data is consumed from the UDP endpoints. So far I have only seen BSM, MAP, and SPAT data come through the raw encoded json topics. This isn't super concerning to me since the logs confirm that all receiver threads are initialized on startup.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/develop/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
