### PR TITLE
K-Table Memory Usage Bugfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY ./scripts/startup_jpoode.sh /home
 
 RUN apk --no-cache add openssh  \
     && apk --no-cache add openrc  \
-    && rc-update add sshd
+    && rc-update add sshd \
+    && apk add libstdc++
 
 ENTRYPOINT ["sh", "/home/startup_jpoode.sh"]

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeTimJsonTopology.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeTimJsonTopology.java
@@ -97,17 +97,8 @@ public class OdeTimJsonTopology {
     ReadOnlyWindowStore<String, String> windowStore =
         streams.store(StoreQueryParameters.fromNameAndType("timjson-windowed-store", QueryableStoreTypes.windowStore()));
 
-    Instant now = Instant.now();
-    Instant start = now.minus(Duration.ofHours(1));
-    String value;
+    Instant start = Instant.now().minus(Duration.ofHours(1));
     
-    try (WindowStoreIterator<String> iterator = windowStore.fetch(uuid, start, now)) {
-      value = null;
-      while (iterator.hasNext()) {
-        value = String.valueOf(iterator.next().value);
-      }
-    }
-    
-    return value;
+    return windowStore.fetch(uuid, start.toEpochMilli());
   }
 }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeTimJsonTopology.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeTimJsonTopology.java
@@ -77,13 +77,13 @@ public class OdeTimJsonTopology {
     KStream<String, String> timStream = builder.stream(topic);
 
     timStream.groupByKey()
-            .windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofHours(1))) // 1 hour window
-            .reduce(
-                    (aggValue, newValue) -> newValue, // only keep latest value
-                    Materialized.<String, String, WindowStore<Bytes, byte[]>>as("timjson-windowed-store")
-                            .withRetention(Duration.ofHours(1))
-                            .withKeySerde(Serdes.String())
-                            .withValueSerde(Serdes.String()));
+        .windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofHours(1))) // 1 hour window
+        .reduce(
+            (aggValue, newValue) -> newValue, // only keep latest value
+            Materialized.<String, String, WindowStore<Bytes, byte[]>>as("timjson-windowed-store")
+                .withRetention(Duration.ofHours(1))
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.String()));
 
     return builder.build();
   }
@@ -99,15 +99,15 @@ public class OdeTimJsonTopology {
 
     Instant now = Instant.now();
     Instant start = now.minus(Duration.ofHours(1));
-    String value;
-    
+
     try (WindowStoreIterator<String> iterator = windowStore.fetch(uuid, start, now)) {
-      value = null;
       while (iterator.hasNext()) {
-        value = String.valueOf(iterator.next().value);
+        var value = String.valueOf(iterator.next().value);
+        if (value != null) {
+          return value;
+        }
       }
     }
-    
-    return value;
+    return null;
   }
 }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeTimJsonTopology.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeTimJsonTopology.java
@@ -97,8 +97,17 @@ public class OdeTimJsonTopology {
     ReadOnlyWindowStore<String, String> windowStore =
         streams.store(StoreQueryParameters.fromNameAndType("timjson-windowed-store", QueryableStoreTypes.windowStore()));
 
-    Instant start = Instant.now().minus(Duration.ofHours(1));
+    Instant now = Instant.now();
+    Instant start = now.minus(Duration.ofHours(1));
+    String value;
     
-    return windowStore.fetch(uuid, start.toEpochMilli());
+    try (WindowStoreIterator<String> iterator = windowStore.fetch(uuid, start, now)) {
+      value = null;
+      while (iterator.hasNext()) {
+        value = String.valueOf(iterator.next().value);
+      }
+    }
+    
+    return value;
   }
 }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeTimJsonTopology.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeTimJsonTopology.java
@@ -1,7 +1,7 @@
 package us.dot.its.jpo.ode;
 
 import java.util.Properties;
-import lombok.extern.slf4j.Slf4j;
+
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StoreQueryParameters;
@@ -11,6 +11,8 @@ import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.Stores;
+
+import lombok.extern.slf4j.Slf4j;
 import us.dot.its.jpo.ode.kafka.OdeKafkaProperties;
 
 
@@ -65,7 +67,7 @@ public class OdeTimJsonTopology {
   public Topology buildTopology(String topic) {
     StreamsBuilder builder = new StreamsBuilder();
     builder.table(topic,
-        Materialized.<String, String>as(Stores.inMemoryKeyValueStore("timjson-store")));
+        Materialized.<String, String>as(Stores.persistentKeyValueStore("timjson-store")));
     return builder.build();
   }
 

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeTimJsonTopology.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeTimJsonTopology.java
@@ -1,16 +1,23 @@
 package us.dot.its.jpo.ode;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Properties;
 
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
-import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.ReadOnlyWindowStore;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.WindowStoreIterator;
 
 import lombok.extern.slf4j.Slf4j;
 import us.dot.its.jpo.ode.kafka.OdeKafkaProperties;
@@ -42,6 +49,7 @@ public class OdeTimJsonTopology {
     streamsProperties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, odeKafkaProps.getBrokers());
     streamsProperties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
     streamsProperties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+    streamsProperties.put(StreamsConfig.WINDOW_SIZE_MS_CONFIG, 3600 * 1000L); // 1 hour retention
 
     if ("CONFLUENT".equals(odeKafkaProps.getKafkaType())) {
       streamsProperties.putAll(odeKafkaProps.getConfluent().buildConfluentProperties());
@@ -66,19 +74,43 @@ public class OdeTimJsonTopology {
    */
   public Topology buildTopology(String topic) {
     StreamsBuilder builder = new StreamsBuilder();
-    builder.table(topic,
-        Materialized.<String, String>as(Stores.persistentKeyValueStore("timjson-store")));
+
+    // Create a windowed store with a retention period of 1 hour
+    KStream<String, String> timStream = builder.stream(topic);
+
+    timStream.groupByKey()
+            .windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofHours(1))) // 1 hour window
+            .reduce(
+                    (aggValue, newValue) -> newValue, // only keep latest value
+                    Materialized.<String, String, WindowStore<Bytes, byte[]>>as("timjson-windowed-store")
+                            .withRetention(Duration.ofHours(1))
+                            .withKeySerde(Serdes.String())
+                            .withValueSerde(Serdes.String())
+            );
+
     return builder.build();
   }
 
   /**
-   * Query the K-Table by a specified UUID.
+   * Query the windowed store by a specified UUID.
    *
    * @param uuid The specified UUID to query for.
    **/
   public String query(String uuid) {
-    return (String) streams.store(
-            StoreQueryParameters.fromNameAndType("timjson-store", QueryableStoreTypes.keyValueStore()))
-        .get(uuid);
+    ReadOnlyWindowStore<String, String> windowStore =
+      streams.store(StoreQueryParameters.fromNameAndType("timjson-windowed-store", QueryableStoreTypes.windowStore()));
+
+    Instant now = Instant.now();
+    Instant start = now.minus(Duration.ofHours(1));
+    String value;
+    
+    try (WindowStoreIterator<String> iterator = windowStore.fetch(uuid, start, now)) {
+        value = null;
+        while (iterator.hasNext()) {
+            value = String.valueOf(iterator.next().value);
+        }
+    }
+    
+    return value;
   }
 }

--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeTimJsonTopology.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeTimJsonTopology.java
@@ -3,7 +3,7 @@ package us.dot.its.jpo.ode;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Properties;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
@@ -18,8 +18,6 @@ import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
-
-import lombok.extern.slf4j.Slf4j;
 import us.dot.its.jpo.ode.kafka.OdeKafkaProperties;
 
 
@@ -85,8 +83,7 @@ public class OdeTimJsonTopology {
                     Materialized.<String, String, WindowStore<Bytes, byte[]>>as("timjson-windowed-store")
                             .withRetention(Duration.ofHours(1))
                             .withKeySerde(Serdes.String())
-                            .withValueSerde(Serdes.String())
-            );
+                            .withValueSerde(Serdes.String()));
 
     return builder.build();
   }
@@ -98,17 +95,17 @@ public class OdeTimJsonTopology {
    **/
   public String query(String uuid) {
     ReadOnlyWindowStore<String, String> windowStore =
-      streams.store(StoreQueryParameters.fromNameAndType("timjson-windowed-store", QueryableStoreTypes.windowStore()));
+        streams.store(StoreQueryParameters.fromNameAndType("timjson-windowed-store", QueryableStoreTypes.windowStore()));
 
     Instant now = Instant.now();
     Instant start = now.minus(Duration.ofHours(1));
     String value;
     
     try (WindowStoreIterator<String> iterator = windowStore.fetch(uuid, start, now)) {
-        value = null;
-        while (iterator.hasNext()) {
-            value = String.valueOf(iterator.next().value);
-        }
+      value = null;
+      while (iterator.hasNext()) {
+        value = String.valueOf(iterator.next().value);
+      }
     }
     
     return value;


### PR DESCRIPTION
# PR Details
## Description

This PR addresses a resource usage bug resulting from using an in-memory store for the OdeTimJson k-table. This has been updated to use a persistent store, bringing the JVM heap usage down from ~99% to ~30%. 

## Motivation and Context

This update prevents pod restarts and out of memory errors in the ODE due to the OdeTimJson k-table. 

## How Has This Been Tested?

This has been tested locally using docker compose and was deployed/tested in the CDOT dev environment. During testing in dev, heap usage hovered around 30%. Additionally, I verified that messages were still being correctly produced to topic.OdeTimJsonTMCFiltered. 

## Types of changes

- [ X ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/develop/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
