### PR TITLE
Fix kafka streams application ID

### DIFF
--- a/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeTimJsonTopology.java
+++ b/jpo-ode-svcs/src/main/java/us/dot/its/jpo/ode/OdeTimJsonTopology.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
@@ -43,11 +44,14 @@ public class OdeTimJsonTopology {
   public OdeTimJsonTopology(OdeKafkaProperties odeKafkaProps, String topic) {
 
     Properties streamsProperties = new Properties();
-    streamsProperties.put(StreamsConfig.APPLICATION_ID_CONFIG, "KeyedOdeTimJson");
+    Uuid uuid = Uuid.randomUuid();
+    streamsProperties.put(StreamsConfig.APPLICATION_ID_CONFIG, "KeyedOdeTimJson-" + uuid);
     streamsProperties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, odeKafkaProps.getBrokers());
     streamsProperties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
     streamsProperties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
     streamsProperties.put(StreamsConfig.WINDOW_SIZE_MS_CONFIG, 3600 * 1000L); // 1 hour retention
+    streamsProperties.put(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG, 1800 * 1000L); // 30 minute retention
+
 
     if ("CONFLUENT".equals(odeKafkaProps.getKafkaType())) {
       streamsProperties.putAll(odeKafkaProps.getConfluent().buildConfluentProperties());


### PR DESCRIPTION
# PR Details
## Description

This PR adds a unique identifier to the Kafka Streams application ID during OdeTimJsonTopology initialization, ensuring that each ODE replica can access a distinct Kafka Streams instance. It also updates the additional retention config property so that the total retention time for created changelog topics is 1.5 hours.

## Related Issue

There is no related issue for this fix.

## Motivation and Context

This change fixes incorrect Kafka Streams access for multiple deployed ODE replicas. This prevents offset/access errors when there is more than one ODE replica.

## How Has This Been Tested?

These changes were deployed in test and verified to work correctly when depositing TIMs. Unit tests were also verified to pass using Maven.

## Types of changes

- [ X ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/develop/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
