### PR TITLE
Modify Sonar CI Job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   sonar:
+    if: github.event.pull_request.base.repo.owner.login == 'usdot-jpo-ode'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Modifies the sonar CI job to only run when the target branch is owned by the usdot-jpo-ode organization.