### PR TITLE
Ensure the artifact publish CI recursively initializes submodules

### DIFF
--- a/.github/workflows/artifact-publish.yml
+++ b/.github/workflows/artifact-publish.yml
@@ -12,8 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
+    - name: Checkout code (with submodules)
       uses: actions/checkout@v4
+      with:
+        submodules: recursive
 
     - name: Set up JDK 21
       uses: actions/setup-java@v4


### PR DESCRIPTION
Addresses the CI artifact publish GitHub action to make sure to initialize its submodules to not have issues with building the image with the jpo-asn-pojos dependency,