### PR TITLE
Fix: run tests in ci.yml without sonar when not in USDOT-owned branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,21 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  test-no-sonar:
+    if: github.event.pull_request.base.repo.owner.login != 'usdot-jpo-ode'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+      - name: Build and test
+        run: mvn clean verify
+
   sonar:
     if: github.event.pull_request.base.repo.owner.login == 'usdot-jpo-ode'
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Run tests in ci.yml without Sonar when not in a USDOT-owned branch. The existing CI only runs tests in the `sonar` step, which only runs when USDOT owns the branch. This means we don't get the value of automatic tests and PR blockers if tests fail. This replaces the automated testing without doubling our test costs when targeting a USDOT-owned branch.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[ODE Contributing Guide](https://github.com/usdot-jpo-ode/jpo-ode/blob/develop/docs/contributing_guide.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
