### PR TITLE
Allow Kafka to be shared outside of ODE Network

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -63,6 +63,10 @@ DEFAULT_SNMP_PROTOCOL=
 #########################
 # Kafka and Confluent Cloud Properties
 
+# While not strictly required for the ODE to operate properly. Setting this value is required to allow applications outside of the ODE's docker network to connect to Kafka.
+# to connect to Kafka.
+KAFKA_BOOTSTRAP_SERVERS=${DOCKER_HOST_IP}:9092
+
 # The type of Kafka broker to connect to. If set to "CONFLUENT", the broker will be Confluent Cloud. Otherwise, it will be a local Kafka broker.
 KAFKA_TYPE=
 KAFKA_LINGER_MS=1


### PR DESCRIPTION
Background:
The Bitnami Kafka images used by the ODE only advertise a small selection of ports to listen for new data from applications. This is set in the jpo-utils docker-compose-kafka.yml file [here](https://github.com/usdot-jpo-ode/jpo-utils/blob/d9298120d603b9ff9ce3a5520ce885c8bd7ec23d/docker-compose-kafka.yml)

Specifically: KAFKA_CFG_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9094,EXTERNAL://${KAFKA_BOOTSTRAP_SERVERS:-kafka:9092}"

In the default configuration, this causes the Kafka broker to advertise to connected applications that they should send data to Kafka:9092. For applications such as the ADM and AEM modules this works fine, as they are typically deployed alongside the ODE itself and using a container ID of Kafka will properly route back to the Bitnami container. However, this strategy fails if another container or application outside of the Docker-compose Network tries to connect. For example, spinning up a separate copy of the geojson converter will fail since it cannot route properly back to the hostname Kafka.

This PR solves this issue by directly specifying the KAFKA_BOOTSTRAP_SERVERS env var. This changes the default advertised broker location to be DOCKER_HOST_IP:9092 which is typically routable by external containers.